### PR TITLE
removed deprecated single and tri as valid finger types

### DIFF
--- a/demos/catkin/demo_robot_interface.py
+++ b/demos/catkin/demo_robot_interface.py
@@ -13,6 +13,7 @@ import robot_interfaces
 import trifinger_simulation.drivers
 from trifinger_simulation import finger_types_data
 
+
 def get_random_position(num_fingers=1):
     """Generate a random position within a save range."""
     position_min = np.array([-1, -1, -2] * num_fingers)

--- a/demos/catkin/demo_robot_interface.py
+++ b/demos/catkin/demo_robot_interface.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import robot_interfaces
 import trifinger_simulation.drivers
-
+from trifinger_simulation import finger_types_data
 
 def get_random_position(num_fingers=1):
     """Generate a random position within a save range."""
@@ -27,11 +27,9 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--finger-type",
-        choices=["single", "tri"],
+        choices=finger_types_data.get_valid_finger_types(),
         required=True,
-        help="""Specify whether the Single Finger ("single")
-                        or the TriFinger ("tri") is used.
-                        """,
+        help="""Specify valid finger type""",
     )
     parser.add_argument(
         "--real-time-mode",
@@ -44,14 +42,13 @@ def main():
     args = parser.parse_args()
 
     # select the correct types/functions based on which robot is used
-    if args.finger_type == "single":
-        num_fingers = 1
+    num_fingers = finger_types_data.get_number_of_fingers(args.finger_type)
+    if num_fingers == 1:
         finger_types = robot_interfaces.finger
         create_backend = (
             trifinger_simulation.drivers.create_single_finger_backend
         )
-    else:
-        num_fingers = 3
+    elif num_fingers == 3:
         finger_types = robot_interfaces.trifinger
         create_backend = trifinger_simulation.drivers.create_trifinger_backend
 

--- a/demos/demo_control.py
+++ b/demos/demo_control.py
@@ -12,7 +12,7 @@ from trifinger_simulation import (
     sim_finger,
     visual_objects,
     sample,
-    finger_types_data
+    finger_types_data,
 )
 
 

--- a/demos/demo_control.py
+++ b/demos/demo_control.py
@@ -8,8 +8,12 @@ import argparse
 import numpy as np
 import random
 import time
-from trifinger_simulation import sim_finger, visual_objects, sample
-from trifinger_simulation import finger_types_data
+from trifinger_simulation import (
+    sim_finger,
+    visual_objects,
+    sample,
+    finger_types_data
+)
 
 
 def main():

--- a/python/trifinger_simulation/finger_types_data.py
+++ b/python/trifinger_simulation/finger_types_data.py
@@ -1,5 +1,4 @@
 import typing
-import warnings
 
 
 class FingerTypesDataFormat(typing.NamedTuple):
@@ -14,11 +13,7 @@ class FingerTypesDataFormat(typing.NamedTuple):
 
 finger_types_data = {
     "fingerone": FingerTypesDataFormat("finger.urdf", 1),
-    # for backward compatibility
-    "single": FingerTypesDataFormat("finger.urdf", 1),
     "trifingerone": FingerTypesDataFormat("trifinger.urdf", 3),
-    # for backward compatibility
-    "tri": FingerTypesDataFormat("trifinger.urdf", 3),
     "fingeredu": FingerTypesDataFormat("edu/fingeredu.urdf", 1),
     "trifingeredu": FingerTypesDataFormat("edu/trifingeredu.urdf", 3),
     "trifingerpro": FingerTypesDataFormat("pro/trifingerpro.urdf", 3),
@@ -48,12 +43,6 @@ def check_finger_type(key):
             % (key, finger_types_data.keys())
         )
     else:
-        if key in ["single", "tri"]:
-            warnings.warn(
-                "The '%s' key is deprecated. Please use"
-                " 'fingerone' instead of 'single', and"
-                " 'trifingerone' instead of 'tri." % (key)
-            )
         return key
 
 

--- a/python/trifinger_simulation/real_finger.py
+++ b/python/trifinger_simulation/real_finger.py
@@ -56,7 +56,7 @@ class RealFinger:
         )
 
         if number_of_fingers == 1:
-            if finger_type in ["fingerone"]:
+            if finger_type == "fingerone":
                 config_file_path = os.path.join(
                     rospkg.RosPack().get_path("robot_fingers"),
                     "config",

--- a/python/trifinger_simulation/real_finger.py
+++ b/python/trifinger_simulation/real_finger.py
@@ -56,7 +56,7 @@ class RealFinger:
         )
 
         if number_of_fingers == 1:
-            if finger_type in ["single", "fingerone"]:
+            if finger_type in ["fingerone"]:
                 config_file_path = os.path.join(
                     rospkg.RosPack().get_path("robot_fingers"),
                     "config",
@@ -75,7 +75,7 @@ class RealFinger:
             self.robot = robot_interfaces.finger.Frontend(finger_data)
             self.Action = robot_interfaces.finger.Action
         elif number_of_fingers == 3:
-            if finger_type in ["tri", "trifingerone"]:
+            if finger_type in ["trifingerone"]:
                 config_file_path = os.path.join(
                     rospkg.RosPack().get_path("robot_fingers"),
                     "config",

--- a/python/trifinger_simulation/real_finger.py
+++ b/python/trifinger_simulation/real_finger.py
@@ -75,7 +75,7 @@ class RealFinger:
             self.robot = robot_interfaces.finger.Frontend(finger_data)
             self.Action = robot_interfaces.finger.Action
         elif number_of_fingers == 3:
-            if finger_type in ["trifingerone"]:
+            if finger_type == "trifingerone":
                 config_file_path = os.path.join(
                     rospkg.RosPack().get_path("robot_fingers"),
                     "config",

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -590,12 +590,6 @@ class SimFinger:
                 os.path.dirname(__file__), "robot_properties_fingers"
             )
 
-        if self.finger_type in ["single", "tri"]:
-            warnings.warn(
-                "Finger types 'single' and 'tri' are deprecated."
-                " Use 'fingerone' and 'trifingerone' instead."
-            )
-
         urdf_file = finger_types_data.get_finger_urdf(self.finger_type)
         self.finger_urdf_path = os.path.join(
             self.robot_properties_path, "urdf", urdf_file
@@ -652,14 +646,14 @@ class SimFinger:
                 self.robot_properties_path, "meshes", "stl", filename
             )
 
-        if self.finger_type in ["fingerone", "single", "fingeredu"]:
+        if self.finger_type in ["fingerone", "fingeredu"]:
             collision_objects.import_mesh(
                 mesh_path("Stage_simplified.stl"),
                 position=[0, 0, 0],
                 is_concave=True,
             )
 
-        elif self.finger_type in ["trifingerone", "tri", "trifingerpro"]:
+        elif self.finger_type in ["trifingerone", "trifingerpro"]:
             table_colour = (0.18, 0.15, 0.19, 1.0)
             high_border_colour = (0.73, 0.68, 0.72, 1.0)
             if high_border:

--- a/scripts/pybullet_backend.py
+++ b/scripts/pybullet_backend.py
@@ -4,18 +4,21 @@ import argparse
 import math
 
 import robot_interfaces
-from trifinger_simulation import collision_objects, drivers, camera
+from trifinger_simulation import (
+    collision_objects,
+    drivers,
+    camera,
+    finger_types_data,
+)
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--finger-type",
-        choices=["single", "tri"],
+        choices=finger_types_data.get_valid_finger_types(),
         required=True,
-        help="""Specify whether the Single Finger ("single") or the TriFinger
-            ("tri") is used.
-        """,
+        help="""Pass a valid finger type.""",
     )
     parser.add_argument(
         "--real-time-mode",
@@ -70,11 +73,12 @@ def main():
     args = parser.parse_args()
 
     # select the correct types/functions based on which robot is used
-    if args.finger_type == "single":
+    num_fingers = finger_types_data.get_number_of_fingers(args.finger_type)
+    if num_fingers == 1:
         shared_memory_id = "finger"
         finger_types = robot_interfaces.finger
         create_backend = drivers.create_single_finger_backend
-    else:
+    elif num_fingers == 3:
         shared_memory_id = "trifinger"
         finger_types = robot_interfaces.trifinger
         create_backend = drivers.create_trifinger_backend

--- a/tests/catkin/test_pybullet_backend.py
+++ b/tests/catkin/test_pybullet_backend.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import robot_interfaces
 import trifinger_simulation.drivers
+from trifinger_simulation import finger_types_data
 
 
 class TestPyBulletBackend(unittest.TestCase):
@@ -17,16 +18,17 @@ class TestPyBulletBackend(unittest.TestCase):
         tolerance.
 
         Args:
-            finger_type:  Which robot to use.  One of ("single", "tri").
+            finger_type:  Which robot to use.
             goal_positions:  A list of joint goal positions.
         """
         # select the correct types/functions based on which robot is used
-        if finger_type == "single":
+        num_fingers = finger_types_data.get_number_of_fingers(finger_type)
+        if num_fingers == 1:
             finger_types = robot_interfaces.finger
             create_backend = (
                 trifinger_simulation.drivers.create_single_finger_backend
             )
-        else:
+        elif num_fingers == 3:
             finger_types = robot_interfaces.trifinger
             create_backend = (
                 trifinger_simulation.drivers.create_trifinger_backend

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -22,7 +22,7 @@ class TestSimulationDeterminisim(unittest.TestCase):
         run is compared.  If the simulation behaves deterministically, the
         observations should be equal.
         """
-        finger = SimFinger(finger_type="single",)
+        finger = SimFinger(finger_type="fingerone",)
 
         start_position = [0.5, -0.7, -1.5]
         action = finger.Action(torque=[0.3, 0.3, 0.3])
@@ -59,7 +59,7 @@ class TestSimulationDeterminisim(unittest.TestCase):
             "trifinger_simulation.gym_wrapper:reach-v0",
             control_rate_s=0.02,
             enable_visualization=False,
-            finger_type="single",
+            finger_type="fingerone",
             smoothing_params=smoothing_params,
         )
 

--- a/tests/test_reset_joints.py
+++ b/tests/test_reset_joints.py
@@ -20,7 +20,7 @@ class TestResetJoints(unittest.TestCase):
         Send hundred states (positions + velocities) to all the 1DOF joints
         of the fingers and assert they exactly reach these states.
         """
-        finger = SimFinger(finger_type="single",)
+        finger = SimFinger(finger_type="fingerone",)
 
         for _ in range(100):
             state_positions = sample.random_joint_positions(

--- a/tests/test_robot_equivalent_interface.py
+++ b/tests/test_robot_equivalent_interface.py
@@ -13,7 +13,9 @@ class TestRobotEquivalentInterface(unittest.TestCase):
 
     def setUp(self):
         self.finger = SimFinger(
-            finger_type="fingerone", time_step=0.001, enable_visualization=False,
+            finger_type="fingerone",
+            time_step=0.001,
+            enable_visualization=False,
         )
 
         self.start_position = [0, -0.7, -1.5]

--- a/tests/test_robot_equivalent_interface.py
+++ b/tests/test_robot_equivalent_interface.py
@@ -13,7 +13,7 @@ class TestRobotEquivalentInterface(unittest.TestCase):
 
     def setUp(self):
         self.finger = SimFinger(
-            finger_type="single", time_step=0.001, enable_visualization=False,
+            finger_type="fingerone", time_step=0.001, enable_visualization=False,
         )
 
         self.start_position = [0, -0.7, -1.5]


### PR DESCRIPTION
We do not need these two finger type names anymore... they were creating confusion, so removed them.
## How I Tested

[//]: # "Explain how you tested your changes"

Ran all the unit tests for python and the changed demo files.


- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
