### PR TITLE
fix installation instructions section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,7 @@ The documentation for this repository is available online [here](https://trifing
 
 ## Installation instructions
 
-Find below the installation instructions to install this package as a standalone python package. This package can also be installed as part of a catkin workspace. Please refer to the [installation instructions](docs/installation.rst) for details.
-
-### Prerequisites: Install Anaconda or Miniconda
-
-If not already done, install ``conda`` (Miniconda is sufficient).  To do so, see the
-[official documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/).
-
-We have tested with conda version 4.8.3.
-
-## Install the trifinger_simulation package
-
-Please refer to the `installation instructions <https://trifinger-robot-simulation.readthedocs.io/en/latest/installation.html>`_.
+Please refer to the [installation instructions](https://trifinger-robot-simulation.readthedocs.io/en/latest/installation.html) for details.
 
 ## Cite Us
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,6 @@ sys.path.insert(0, os.path.abspath("../python/"))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 import sphinx_rtd_theme
-import sphinxcontrib.yt
 
 extensions = [
     "sphinx_rtd_theme",


### PR DESCRIPTION
## Description

fixes installation instructions section in readme

## How I Tested

by looking at the readme preview

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
