### PR TITLE
Fix generation of simulated Bayer images

### DIFF
--- a/python/trifinger_simulation/camera.py
+++ b/python/trifinger_simulation/camera.py
@@ -143,8 +143,9 @@ def rbg_to_bayer_bg(image: np.ndarray) -> np.ndarray:
         image: RGB image.
 
     Returns:
-        BG-Bayer pattern based on the input image.  Height and width are the
-        same as of the input image.
+        Bayer pattern based on the input image.  Height and width are the same
+        as of the input image.  The image can be converted using OpenCV's
+        `COLOR_BAYER_BG2*`.
     """
     # there is only one channel but it still needs the third dimension, so that
     # the conversion to a cv::Mat in C++ is easier
@@ -155,16 +156,16 @@ def rbg_to_bayer_bg(image: np.ndarray) -> np.ndarray:
     CHANNEL_GREEN = 1
     CHANNEL_BLUE = 2
 
-    # channel map to get the following pattern:
+    # channel map to get the following pattern (called "BG" in OpenCV):
     #
-    #   BG
-    #   GR
+    #   RG
+    #   GB
     #
     channel_map = {
-        (0, 0): CHANNEL_BLUE,
+        (0, 0): CHANNEL_RED,
         (1, 0): CHANNEL_GREEN,
         (0, 1): CHANNEL_GREEN,
-        (1, 1): CHANNEL_RED,
+        (1, 1): CHANNEL_BLUE,
     }
 
     for r in range(image.shape[0]):


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Contrary to my assumption, the "BG" in OpenCV's "BayerBG" does not refer
to the first row, first two columns of the Bayer pattern but to second
row, second and third column (see
https://docs.opencv.org/3.2.0/de/d25/imgproc_color_conversions.html).

So to get a pattern that can correctly be reconstructed with "BayerBG",
red and blue need to be swapped.


## How I Tested

By converting the generated images back to BGR using the same function as for the images of the real cameras.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
