### PR TITLE
Increase episode length to 2min for challenge phase 2

### DIFF
--- a/python/trifinger_simulation/tasks/move_cube.py
+++ b/python/trifinger_simulation/tasks/move_cube.py
@@ -10,8 +10,8 @@ from scipy.spatial.transform import Rotation
 random = np.random.RandomState()
 
 
-#: Number of time steps in one episode (3750 steps per 0.004s = 15s)
-episode_length = 3750
+#: Number of time steps in one episode
+episode_length = 2 * 60 * 1000
 
 
 _CUBE_WIDTH = 0.065


### PR DESCRIPTION
## Description

Increase episode length to 2 min at 1 kHz for challenge phase 2


## How I Tested

In combination with https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/72.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
