### PR TITLE
Move robot limits to separate file

### DIFF
--- a/python/trifinger_simulation/trifinger_platform.py
+++ b/python/trifinger_simulation/trifinger_platform.py
@@ -1,14 +1,12 @@
 import pickle
 import warnings
 import numpy as np
-
-
-from trifinger_simulation.tasks import move_cube
-from trifinger_simulation.sim_finger import SimFinger
-from trifinger_simulation import camera, collision_objects
+import gym
 from types import SimpleNamespace
 
-import gym
+from .tasks import move_cube
+from .sim_finger import SimFinger
+from . import camera, collision_objects, trifingerpro_limits
 
 
 class ObjectPose:
@@ -67,39 +65,12 @@ class TriFingerPlatform:
     # Create the action and observation spaces
     # ========================================
 
-    _n_joints = 9
-    _n_fingers = 3
-    _max_torque_Nm = 0.36
-    _max_velocity_radps = 10
-
     spaces = SimpleNamespace()
-
-    spaces.robot_torque = SimpleNamespace(
-        low=np.full(_n_joints, -_max_torque_Nm, dtype=np.float32),
-        high=np.full(_n_joints, _max_torque_Nm, dtype=np.float32),
-        default=np.zeros(_n_joints, dtype=np.float32),
-    )
-    spaces.robot_position = SimpleNamespace(
-        low=np.array([-0.33, 0.0, -2.7] * _n_fingers, dtype=np.float32),
-        high=np.array([1.0, 1.57, 0.0] * _n_fingers, dtype=np.float32),
-        default=np.array([0.0, 0.9, -1.7] * _n_fingers, dtype=np.float32),
-    )
-    spaces.robot_velocity = SimpleNamespace(
-        low=np.full(_n_joints, -_max_velocity_radps, dtype=np.float32),
-        high=np.full(_n_joints, _max_velocity_radps, dtype=np.float32),
-        default=np.zeros(_n_joints, dtype=np.float32),
-    )
-    spaces.object_position = SimpleNamespace(
-        low=np.array([-0.3, -0.3, 0], dtype=np.float32),
-        high=np.array([0.3, 0.3, 0.3], dtype=np.float32),
-        default=np.array([0, 0, move_cube._min_height], dtype=np.float32),
-    )
-
-    spaces.object_orientation = SimpleNamespace(
-        low=-np.ones(4, dtype=np.float32),
-        high=np.ones(4, dtype=np.float32),
-        default=move_cube.Pose().orientation,
-    )
+    spaces.robot_torque = trifingerpro_limits.robot_torque
+    spaces.robot_position = trifingerpro_limits.robot_position
+    spaces.robot_velocity = trifingerpro_limits.robot_velocity
+    spaces.object_position = trifingerpro_limits.object_position
+    spaces.object_orientation = trifingerpro_limits.object_orientation
 
     # for convenience, we also create the respective gym spaces
     spaces.robot_torque.gym = gym.spaces.Box(

--- a/python/trifinger_simulation/trifingerpro_limits.py
+++ b/python/trifinger_simulation/trifingerpro_limits.py
@@ -1,0 +1,44 @@
+"""Limits (torques, joint positions, etc.) of the TriFingerPro platform."""
+from types import SimpleNamespace
+import numpy as np
+
+from .tasks import move_cube
+
+
+n_joints = 9
+n_fingers = 3
+max_torque_Nm = 0.36
+max_velocity_radps = 10
+
+
+#: Joint torque limits [Nm]
+robot_torque = SimpleNamespace(
+    low=np.full(n_joints, -max_torque_Nm, dtype=np.float32),
+    high=np.full(n_joints, max_torque_Nm, dtype=np.float32),
+    default=np.zeros(n_joints, dtype=np.float32),
+)
+#: Joint position limits [rad]
+robot_position = SimpleNamespace(
+    low=np.array([-0.33, 0.0, -2.7] * n_fingers, dtype=np.float32),
+    high=np.array([1.0, 1.57, 0.0] * n_fingers, dtype=np.float32),
+    default=np.array([0.0, 0.9, -1.7] * n_fingers, dtype=np.float32),
+)
+#: Joint velocity limits [rad/s]
+robot_velocity = SimpleNamespace(
+    low=np.full(n_joints, -max_velocity_radps, dtype=np.float32),
+    high=np.full(n_joints, max_velocity_radps, dtype=np.float32),
+    default=np.zeros(n_joints, dtype=np.float32),
+)
+
+#: Object position limits [m]
+object_position = SimpleNamespace(
+    low=np.array([-0.3, -0.3, 0], dtype=np.float32),
+    high=np.array([0.3, 0.3, 0.3], dtype=np.float32),
+    default=np.array([0, 0, move_cube._min_height], dtype=np.float32),
+)
+#: Object orientation limits
+object_orientation = SimpleNamespace(
+    low=-np.ones(4, dtype=np.float32),
+    high=np.ones(4, dtype=np.float32),
+    default=move_cube.Pose().orientation,
+)


### PR DESCRIPTION
## Description

Add module with TriFingerPro limits.  By having this in a separate file it can be used more generally.
With this, the `spaces` attribute could probably be removed completely from `TriFingerPlatform`. However, I want to avoid unnecessary changes like this at the moment, so for now keep it there.

Also changed some imports from the same package to relative imports as this improves auto-completion in my editor (this way it finds the files without the need to install the package).


## How I Tested
By running demo_trifinger_platform.py


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
