### PR TITLE
Spawn the cube in the centre of the arena

### DIFF
--- a/scripts/pybullet_backend.py
+++ b/scripts/pybullet_backend.py
@@ -151,8 +151,8 @@ def main():
         # images to save time.
         import trifinger_object_tracking.py_tricamera_types as tricamera
 
-        # spawn a cube in the arena
-        cube = collision_objects.Block()
+        # spawn a cube in the centre of the arena
+        cube = collision_objects.Block(position=[0.0, 0.0, 0.035])
         render_images = args.cameras
 
         camera_data = tricamera.MultiProcessData("tricamera", True, 10)


### PR DESCRIPTION
## Description

The default position is shifted to the side, so explicitly set it to the
centre of the arena, to match better with the real system.


## How I Tested
Executing a challenge job locally in simulation.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
