### PR TITLE
Use small Cuboid instead of Cube

### DIFF
--- a/example/example_pushing_training_env.py
+++ b/example/example_pushing_training_env.py
@@ -203,7 +203,7 @@ class ExamplePushingTrainingEnv(gym.Env):
                 width=0.065,
                 position=goal_object_pose.position,
                 orientation=goal_object_pose.orientation,
-                physicsClientId=self.platform.simfinger._pybullet_client_id,
+                pybullet_client_id=self.platform.simfinger._pybullet_client_id,
             )
 
         self.info = dict()

--- a/python/trifinger_simulation/collision_objects.py
+++ b/python/trifinger_simulation/collision_objects.py
@@ -64,7 +64,7 @@ class Cuboid:
         self,
         position,
         orientation,
-        half_extends,
+        half_extents,
         mass,
         pybullet_client_id=0,
     ):
@@ -75,14 +75,14 @@ class Cuboid:
             position (list): Initial xyz-position of the cuboid.
             orientation (list): Initial orientation quaternion (x, y, z, w) of
                 the cuboid.
-            half_extends (list): Half-extends of the cuboid in x/y/z-direction.
+            half_extents (list): Half-extends of the cuboid in x/y/z-direction.
             mass (float): Mass of the cuboid in kg.
         """
         self._pybullet_client_id = pybullet_client_id
 
         self.block_id = pybullet.createCollisionShape(
             shapeType=pybullet.GEOM_BOX,
-            halfExtents=half_extends,
+            halfExtents=half_extents,
             physicsClientId=self._pybullet_client_id,
         )
         self.block = pybullet.createMultiBody(

--- a/python/trifinger_simulation/collision_objects.py
+++ b/python/trifinger_simulation/collision_objects.py
@@ -57,43 +57,40 @@ def import_mesh(
     return obj
 
 
-class Block:
-    """
-    To interact with a block object
-    """
+class Cuboid:
+    """A cuboid which can be interacted with."""
 
     def __init__(
         self,
-        position=[0.15, 0.0, 0.0425],
-        orientation=[0, 0, 0, 1],
-        half_size=0.0325,
-        mass=0.08,
-        **kwargs,
+        position,
+        orientation,
+        half_extends,
+        mass,
+        pybullet_client_id=0,
     ):
         """
         Import the block
 
         Args:
-            position (list): where in xyz space should the block
-                be imported
-            orientation (list): initial orientation quaternion of the block
-            half_size (float): how large should this block be
-            mass (float): how heavy should this block be
+            position (list): Initial xyz-position of the cuboid.
+            orientation (list): Initial orientation quaternion (x, y, z, w) of
+                the cuboid.
+            half_extends (list): Half-extends of the cuboid in x/y/z-direction.
+            mass (float): Mass of the cuboid in kg.
         """
-
-        self._kwargs = kwargs
+        self._pybullet_client_id = pybullet_client_id
 
         self.block_id = pybullet.createCollisionShape(
             shapeType=pybullet.GEOM_BOX,
-            halfExtents=[half_size] * 3,
-            **self._kwargs,
+            halfExtents=half_extends,
+            physicsClientId=self._pybullet_client_id,
         )
         self.block = pybullet.createMultiBody(
             baseCollisionShapeIndex=self.block_id,
             basePosition=position,
             baseOrientation=orientation,
             baseMass=mass,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
 
         # set dynamics of the block
@@ -106,42 +103,58 @@ class Block:
             lateralFriction=lateral_friction,
             spinningFriction=spinning_friction,
             restitution=restitution,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
 
     def set_state(self, position, orientation):
         """
-        Resets the block state to the provided position and
-        orientation
+        Resets the cuboid to the provided position and orientation
 
         Args:
-            position: the position to which the block is to be
-                set
-            orientation: desired to be set
+            position: New position.
+            orientation: New orientation.
         """
         pybullet.resetBasePositionAndOrientation(
             self.block,
             position,
             orientation,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
 
     def get_state(self):
         """
         Returns:
-            Current position and orientation of the block.
+            Current position and orientation of the cuboid.
         """
         position, orientation = pybullet.getBasePositionAndOrientation(
             self.block,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
         return list(position), list(orientation)
 
     def __del__(self):
         """
-        Removes the block from the environment
+        Removes the cuboid from the environment.
         """
         # At this point it may be that pybullet was already shut down. To avoid
         # an error, only remove the object if the simulation is still running.
-        if pybullet.isConnected(**self._kwargs):
-            pybullet.removeBody(self.block, **self._kwargs)
+        if pybullet.isConnected(self._pybullet_client_id):
+            pybullet.removeBody(self.block, self._pybullet_client_id)
+
+
+class Cube(Cuboid):
+    """A cube object."""
+    def __init__(
+        self,
+        position=[0.15, 0.0, 0.0425],
+        orientation=[0, 0, 0, 1],
+        half_width=0.0325,
+        mass=0.08,
+        pybullet_client_id=0,
+    ):
+        super().__init__(position, orientation, [half_width] * 3, mass,
+                         pybullet_client_id)
+
+
+# For backward compatibility
+Block = Cube

--- a/python/trifinger_simulation/collision_objects.py
+++ b/python/trifinger_simulation/collision_objects.py
@@ -144,6 +144,7 @@ class Cuboid:
 
 class Cube(Cuboid):
     """A cube object."""
+
     def __init__(
         self,
         position=[0.15, 0.0, 0.0425],
@@ -152,8 +153,9 @@ class Cube(Cuboid):
         mass=0.08,
         pybullet_client_id=0,
     ):
-        super().__init__(position, orientation, [half_width] * 3, mass,
-                         pybullet_client_id)
+        super().__init__(
+            position, orientation, [half_width] * 3, mass, pybullet_client_id
+        )
 
 
 # For backward compatibility

--- a/python/trifinger_simulation/gym_wrapper/envs/cube_env.py
+++ b/python/trifinger_simulation/gym_wrapper/envs/cube_env.py
@@ -274,11 +274,11 @@ class CubeEnv(gym.GoalEnv):
 
         # visualize the goal
         if self.visualization:
-            self.goal_marker = visual_objects.CubeMarker(
-                width=0.065,
+            self.goal_marker = visual_objects.CuboidMarker(
+                size=(0.02, 0.08, 0.02),
                 position=goal_object_pose.position,
                 orientation=goal_object_pose.orientation,
-                physicsClientId=self.platform.simfinger._pybullet_client_id,
+                pybullet_client_id=self.platform.simfinger._pybullet_client_id,
             )
 
         self.info = {"difficulty": self.initializer.difficulty}

--- a/python/trifinger_simulation/tasks/move_cube.py
+++ b/python/trifinger_simulation/tasks/move_cube.py
@@ -38,7 +38,8 @@ _cube_corners = (
             [+1, +1, -1],
             [+1, +1, +1],
         ]
-    ) * _CUBOID_HALF_SIZE
+    )
+    * _CUBOID_HALF_SIZE
 )
 
 

--- a/python/trifinger_simulation/tasks/move_cube.py
+++ b/python/trifinger_simulation/tasks/move_cube.py
@@ -14,13 +14,15 @@ random = np.random.RandomState()
 episode_length = 2 * 60 * 1000
 
 
-_CUBE_WIDTH = 0.065
+_CUBOID_SIZE = np.array((0.02, 0.08, 0.02))
+_CUBOID_HALF_SIZE = _CUBOID_SIZE / 2
+
 _ARENA_RADIUS = 0.195
 
-_cube_3d_radius = _CUBE_WIDTH * np.sqrt(3) / 2
+_cube_3d_radius = np.linalg.norm(_CUBOID_HALF_SIZE)
 _max_cube_com_distance_to_center = _ARENA_RADIUS - _cube_3d_radius
 
-_min_height = _CUBE_WIDTH / 2
+_min_height = min(_CUBOID_HALF_SIZE)
 _max_height = 0.1
 
 
@@ -36,8 +38,7 @@ _cube_corners = (
             [+1, +1, -1],
             [+1, +1, +1],
         ]
-    )
-    * (_CUBE_WIDTH / 2)
+    ) * _CUBOID_HALF_SIZE
 )
 
 
@@ -144,12 +145,12 @@ def sample_goal(difficulty):
     if difficulty == -1:  # for initialization
         # on the ground, random yaw
         x, y = random_xy()
-        z = _CUBE_WIDTH / 2
+        z = _min_height
         orientation = random_yaw_orientation()
 
     elif difficulty == 1:
         x, y = random_xy()
-        z = _CUBE_WIDTH / 2
+        z = _min_height
         orientation = np.array([0, 0, 0, 1])
 
     elif difficulty == 2:

--- a/python/trifinger_simulation/trifinger_platform.py
+++ b/python/trifinger_simulation/trifinger_platform.py
@@ -154,7 +154,7 @@ class TriFingerPlatform:
         self.cube = collision_objects.Cuboid(
             position=initial_object_pose.position,
             orientation=initial_object_pose.orientation,
-            half_extends=[0.01, 0.04, 0.01],
+            half_extents=[0.01, 0.04, 0.01],
             mass=0.016,
             pybullet_client_id=self.simfinger._pybullet_client_id,
         )

--- a/python/trifinger_simulation/trifinger_platform.py
+++ b/python/trifinger_simulation/trifinger_platform.py
@@ -150,11 +150,13 @@ class TriFingerPlatform:
                 position=self.spaces.object_position.default,
                 orientation=self.spaces.object_orientation.default,
             )
-        self.cube = collision_objects.Block(
-            initial_object_pose.position,
-            initial_object_pose.orientation,
-            mass=0.020,
-            **_kwargs,
+
+        self.cube = collision_objects.Cuboid(
+            position=initial_object_pose.position,
+            orientation=initial_object_pose.orientation,
+            half_extends=[0.01, 0.04, 0.01],
+            mass=0.016,
+            pybullet_client_id=self.simfinger._pybullet_client_id,
         )
 
         self.tricamera = camera.TriFingerCameras(**_kwargs)

--- a/python/trifinger_simulation/visual_objects.py
+++ b/python/trifinger_simulation/visual_objects.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pybullet
 
 
@@ -75,40 +76,41 @@ class Marker:
             )
 
 
-class CubeMarker:
-    """Visualize a cube."""
+class ObjectMarker:
 
     def __init__(
         self,
-        width,
+        shape_type,
         position,
         orientation,
         color=(0, 1, 0, 0.5),
+        pybullet_client_id=0,
         **kwargs,
     ):
         """
         Create a cube marker for visualization
 
         Args:
-            width (float): Length of one side of the cube.
+            shape_type: Shape type of the object (e.g. pybullet.GEOM_BOX).
             position: Position (x, y, z)
             orientation: Orientation as quaternion (x, y, z, w)
-            color: Color of the cube as a tuple (r, b, g, q)
+            kwargs: Keyword arguments that are passed to
+                pybullet.createVisualShape.  Use this to specify
+                shape-type-specify parameters like the object size.
         """
-
-        self._kwargs = kwargs
+        self._pybullet_client_id = pybullet_client_id
 
         self.shape_id = pybullet.createVisualShape(
             shapeType=pybullet.GEOM_BOX,
-            halfExtents=[width / 2] * 3,
             rgbaColor=color,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
+            **kwargs,
         )
         self.body_id = pybullet.createMultiBody(
             baseVisualShapeIndex=self.shape_id,
             basePosition=position,
             baseOrientation=orientation,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
 
     def set_state(self, position, orientation):
@@ -122,5 +124,56 @@ class CubeMarker:
             self.body_id,
             position,
             orientation,
-            **self._kwargs,
+            physicsClientId=self._pybullet_client_id,
         )
+
+
+class CuboidMarker(ObjectMarker):
+    """Visualize a Cuboid."""
+
+    def __init__(
+        self,
+        size,
+        position,
+        orientation,
+        color=(0, 1, 0, 0.5),
+        pybullet_client_id=0,
+    ):
+        """
+        Create a cube marker for visualization
+
+        Args:
+            size (list): Lengths of the cuboid sides.
+            position: Position (x, y, z)
+            orientation: Orientation as quaternion (x, y, z, w)
+            color: Color of the cube as a tuple (r, b, g, a)
+        """
+        size = np.asarray(size)
+        super().__init__(pybullet.GEOM_BOX, position, orientation, color,
+                         pybullet_client_id, halfExtents=size / 2,
+                         )
+
+
+class CubeMarker(CuboidMarker):
+    """Visualize a cube."""
+
+    def __init__(
+        self,
+        width,
+        position,
+        orientation,
+        color=(0, 1, 0, 0.5),
+        pybullet_client_id=0,
+    ):
+        """
+        Create a cube marker for visualization
+
+        Args:
+            width (float): Length of one side of the cube.
+            position: Position (x, y, z)
+            orientation: Orientation as quaternion (x, y, z, w)
+            color: Color of the cube as a tuple (r, b, g, a)
+        """
+        super().__init__([width] * 3, position, orientation, color,
+                         pybullet_client_id,
+                         )

--- a/python/trifinger_simulation/visual_objects.py
+++ b/python/trifinger_simulation/visual_objects.py
@@ -100,7 +100,7 @@ class ObjectMarker:
         self._pybullet_client_id = pybullet_client_id
 
         self.shape_id = pybullet.createVisualShape(
-            shapeType=pybullet.GEOM_BOX,
+            shapeType=shape_type,
             rgbaColor=color,
             physicsClientId=self._pybullet_client_id,
             **kwargs,

--- a/python/trifinger_simulation/visual_objects.py
+++ b/python/trifinger_simulation/visual_objects.py
@@ -77,7 +77,6 @@ class Marker:
 
 
 class ObjectMarker:
-
     def __init__(
         self,
         shape_type,
@@ -149,9 +148,14 @@ class CuboidMarker(ObjectMarker):
             color: Color of the cube as a tuple (r, b, g, a)
         """
         size = np.asarray(size)
-        super().__init__(pybullet.GEOM_BOX, position, orientation, color,
-                         pybullet_client_id, halfExtents=size / 2,
-                         )
+        super().__init__(
+            pybullet.GEOM_BOX,
+            position,
+            orientation,
+            color,
+            pybullet_client_id,
+            halfExtents=size / 2,
+        )
 
 
 class CubeMarker(CuboidMarker):
@@ -174,6 +178,10 @@ class CubeMarker(CuboidMarker):
             orientation: Orientation as quaternion (x, y, z, w)
             color: Color of the cube as a tuple (r, b, g, a)
         """
-        super().__init__([width] * 3, position, orientation, color,
-                         pybullet_client_id,
-                         )
+        super().__init__(
+            [width] * 3,
+            position,
+            orientation,
+            color,
+            pybullet_client_id,
+        )

--- a/scripts/pybullet_backend.py
+++ b/scripts/pybullet_backend.py
@@ -152,7 +152,13 @@ def main():
         import trifinger_object_tracking.py_tricamera_types as tricamera
 
         # spawn a cube in the centre of the arena
-        cube = collision_objects.Block(position=[0.0, 0.0, 0.035])
+        cube = collision_objects.Cuboid(
+            position=[0.0, 0.0, 0.01],
+            orientation=[0, 0, 0, 1],
+            half_extends=[0.01, 0.04, 0.01],
+            mass=0.016,
+        )
+
         render_images = args.cameras
 
         camera_data = tricamera.MultiProcessData("tricamera", True, 10)

--- a/scripts/pybullet_backend.py
+++ b/scripts/pybullet_backend.py
@@ -155,7 +155,7 @@ def main():
         cube = collision_objects.Cuboid(
             position=[0.0, 0.0, 0.01],
             orientation=[0, 0, 0, 1],
-            half_extends=[0.01, 0.04, 0.01],
+            half_extents=[0.01, 0.04, 0.01],
             mass=0.016,
         )
 

--- a/tests/test_cube_env.py
+++ b/tests/test_cube_env.py
@@ -20,8 +20,10 @@ class TestSample(unittest.TestCase):
             action = env.action_space.sample()
             observation, _, _, _ = env.step(action)
 
-            self.assertTrue(env.observation_space.contains(observation),
-                            msg="Invalid observation: {}".format(observation))
+            self.assertTrue(
+                env.observation_space.contains(observation),
+                msg="Invalid observation: {}".format(observation),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_tasks_move_cube.py
+++ b/tests/test_tasks_move_cube.py
@@ -11,18 +11,18 @@ class TestMoveCube(unittest.TestCase):
 
     def test_get_cube_corner_positions(self):
         # cube half width
-        chw = move_cube._CUBE_WIDTH / 2
+        chw = move_cube._CUBOID_HALF_SIZE
         # no transformation
         expected_origin_corners = np.array(
             [
-                [-chw, -chw, -chw],
-                [-chw, -chw, +chw],
-                [-chw, +chw, -chw],
-                [-chw, +chw, +chw],
-                [+chw, -chw, -chw],
-                [+chw, -chw, +chw],
-                [+chw, +chw, -chw],
-                [+chw, +chw, +chw],
+                [-chw[0], -chw[1], -chw[2]],
+                [-chw[0], -chw[1], +chw[2]],
+                [-chw[0], +chw[1], -chw[2]],
+                [-chw[0], +chw[1], +chw[2]],
+                [+chw[0], -chw[1], -chw[2]],
+                [+chw[0], -chw[1], +chw[2]],
+                [+chw[0], +chw[1], -chw[2]],
+                [+chw[0], +chw[1], +chw[2]],
             ]
         )
         origin = move_cube.Pose()
@@ -34,14 +34,14 @@ class TestMoveCube(unittest.TestCase):
         # only translation
         expected_translated_corners = np.array(
             [
-                [-chw + 1, -chw + 2, -chw + 3],
-                [-chw + 1, -chw + 2, +chw + 3],
-                [-chw + 1, +chw + 2, -chw + 3],
-                [-chw + 1, +chw + 2, +chw + 3],
-                [+chw + 1, -chw + 2, -chw + 3],
-                [+chw + 1, -chw + 2, +chw + 3],
-                [+chw + 1, +chw + 2, -chw + 3],
-                [+chw + 1, +chw + 2, +chw + 3],
+                [-chw[0] + 1, -chw[1] + 2, -chw[2] + 3],
+                [-chw[0] + 1, -chw[1] + 2, +chw[2] + 3],
+                [-chw[0] + 1, +chw[1] + 2, -chw[2] + 3],
+                [-chw[0] + 1, +chw[1] + 2, +chw[2] + 3],
+                [+chw[0] + 1, -chw[1] + 2, -chw[2] + 3],
+                [+chw[0] + 1, -chw[1] + 2, +chw[2] + 3],
+                [+chw[0] + 1, +chw[1] + 2, -chw[2] + 3],
+                [+chw[0] + 1, +chw[1] + 2, +chw[2] + 3],
             ]
         )
         translated = move_cube.get_cube_corner_positions(
@@ -55,14 +55,14 @@ class TestMoveCube(unittest.TestCase):
         rot_z90 = Rotation.from_euler("z", 90, degrees=True).as_quat()
         expected_rotated_corners = np.array(
             [
-                [+chw, -chw, -chw],
-                [+chw, -chw, +chw],
-                [-chw, -chw, -chw],
-                [-chw, -chw, +chw],
-                [+chw, +chw, -chw],
-                [+chw, +chw, +chw],
-                [-chw, +chw, -chw],
-                [-chw, +chw, +chw],
+                [+chw[1], -chw[0], -chw[2]],
+                [+chw[1], -chw[0], +chw[2]],
+                [-chw[1], -chw[0], -chw[2]],
+                [-chw[1], -chw[0], +chw[2]],
+                [+chw[1], +chw[0], -chw[2]],
+                [+chw[1], +chw[0], +chw[2]],
+                [-chw[1], +chw[0], -chw[2]],
+                [-chw[1], +chw[0], +chw[2]],
             ]
         )
         rotated = move_cube.get_cube_corner_positions(
@@ -73,14 +73,14 @@ class TestMoveCube(unittest.TestCase):
         # both rotation and translation
         expected_both_corners = np.array(
             [
-                [+chw + 1, -chw + 2, -chw + 3],
-                [+chw + 1, -chw + 2, +chw + 3],
-                [-chw + 1, -chw + 2, -chw + 3],
-                [-chw + 1, -chw + 2, +chw + 3],
-                [+chw + 1, +chw + 2, -chw + 3],
-                [+chw + 1, +chw + 2, +chw + 3],
-                [-chw + 1, +chw + 2, -chw + 3],
-                [-chw + 1, +chw + 2, +chw + 3],
+                [+chw[1] + 1, -chw[0] + 2, -chw[2] + 3],
+                [+chw[1] + 1, -chw[0] + 2, +chw[2] + 3],
+                [-chw[1] + 1, -chw[0] + 2, -chw[2] + 3],
+                [-chw[1] + 1, -chw[0] + 2, +chw[2] + 3],
+                [+chw[1] + 1, +chw[0] + 2, -chw[2] + 3],
+                [+chw[1] + 1, +chw[0] + 2, +chw[2] + 3],
+                [-chw[1] + 1, +chw[0] + 2, -chw[2] + 3],
+                [-chw[1] + 1, +chw[0] + 2, +chw[2] + 3],
             ]
         )
         both = move_cube.get_cube_corner_positions(
@@ -88,7 +88,7 @@ class TestMoveCube(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(expected_both_corners, both)
 
-    def test_sample_goal_difficulty_1_no_initial_pose(self):
+    def test_sample_goal_difficulty_1(self):
         for i in range(1000):
             goal = move_cube.sample_goal(difficulty=1)
             # verify the goal is valid (i.e. within the allowed ranges)
@@ -103,12 +103,12 @@ class TestMoveCube(unittest.TestCase):
 
             # verify the goal satisfies conditions of difficulty 1
             # always on ground
-            self.assertEqual(goal.position[2], move_cube._CUBE_WIDTH / 2)
+            self.assertEqual(goal.position[2], move_cube._CUBOID_HALF_SIZE[2])
 
             # no orientation
             np.testing.assert_array_equal(goal.orientation, [0, 0, 0, 1])
 
-    def test_sample_goal_difficulty_2_no_initial_pose(self):
+    def test_sample_goal_difficulty_2(self):
         for i in range(1000):
             goal = move_cube.sample_goal(difficulty=2)
             # verify the goal is valid (i.e. within the allowed ranges)
@@ -128,7 +128,7 @@ class TestMoveCube(unittest.TestCase):
             # no orientation
             np.testing.assert_array_equal(goal.orientation, [0, 0, 0, 1])
 
-    def test_sample_goal_difficulty_3_no_initial_pose(self):
+    def test_sample_goal_difficulty_3(self):
         for i in range(1000):
             goal = move_cube.sample_goal(difficulty=3)
             # verify the goal is valid (i.e. within the allowed ranges)
@@ -148,7 +148,7 @@ class TestMoveCube(unittest.TestCase):
             # no orientation
             np.testing.assert_array_equal(goal.orientation, [0, 0, 0, 1])
 
-    def test_sample_goal_difficulty_4_no_initial_pose(self):
+    def test_sample_goal_difficulty_4(self):
         for i in range(1000):
             goal = move_cube.sample_goal(difficulty=4)
             # verify the goal is valid (i.e. within the allowed ranges)
@@ -270,21 +270,21 @@ class TestMoveCube(unittest.TestCase):
         )
 
     def test_validate_goal(self):
-        half_width = move_cube._CUBE_WIDTH / 2
+        on_ground_height = move_cube._CUBOID_HALF_SIZE[2]
         yaw_rotation = Rotation.from_euler("z", 0.42).as_quat()
         full_rotation = Rotation.from_euler("zxz", [0.42, 0.1, -2.3]).as_quat()
 
         # test some valid goals
         try:
             move_cube.validate_goal(
-                move_cube.Pose([0, 0, half_width], [0, 0, 0, 1])
+                move_cube.Pose([0, 0, on_ground_height], [0, 0, 0, 1])
             )
         except Exception as e:
             self.fail("Valid goal was considered invalid because %s" % e)
 
         try:
             move_cube.validate_goal(
-                move_cube.Pose([0.05, -0.1, half_width], yaw_rotation)
+                move_cube.Pose([0.05, -0.1, on_ground_height], yaw_rotation)
             )
         except Exception as e:
             self.fail("Valid goal was considered invalid because %s" % e)
@@ -307,11 +307,11 @@ class TestMoveCube(unittest.TestCase):
         # invalid positions
         with self.assertRaises(move_cube.InvalidGoalError):
             move_cube.validate_goal(
-                move_cube.Pose([0.3, 0, half_width], [0, 0, 0, 1])
+                move_cube.Pose([0.3, 0, on_ground_height], [0, 0, 0, 1])
             )
         with self.assertRaises(move_cube.InvalidGoalError):
             move_cube.validate_goal(
-                move_cube.Pose([0, -0.3, half_width], [0, 0, 0, 1])
+                move_cube.Pose([0, -0.3, on_ground_height], [0, 0, 0, 1])
             )
         with self.assertRaises(move_cube.InvalidGoalError):
             move_cube.validate_goal(move_cube.Pose([0, 0, 0.3], [0, 0, 0, 1]))
@@ -325,7 +325,7 @@ class TestMoveCube(unittest.TestCase):
         # valid CoM position but rotation makes it reach out of valid range
         with self.assertRaises(move_cube.InvalidGoalError):
             move_cube.validate_goal(
-                move_cube.Pose([0, 0, half_width], full_rotation)
+                move_cube.Pose([0, 0, on_ground_height], full_rotation)
             )
 
 


### PR DESCRIPTION
## Description

Change the manipulation object from the 6.5cm cube to the 2x2x8cm cuboid.  This is needed for phase 3 of the challenge.

To reduce the amount of necessary changes during the challenge, I did it in a slightly hacky way by simply replacing the current cube with the cuboid (which is still called "cube" in many places, though).  This way there is no change on the API and the way thinks are executed.  If you think that's bad for master, we can create a separate "challenge" branch.

## How I Tested

By running `demo_random_policy.py` and `pybullet_backend.py`.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
