### PR TITLE
Reward level 4: Ignore rotation around y-axis

### DIFF
--- a/python/trifinger_simulation/tasks/move_cube.py
+++ b/python/trifinger_simulation/tasks/move_cube.py
@@ -293,8 +293,14 @@ def evaluate_state(goal_pose, actual_pose, difficulty):
         # https://stackoverflow.com/a/21905553
         goal_rot = Rotation.from_quat(goal_pose.orientation)
         actual_rot = Rotation.from_quat(actual_pose.orientation)
-        error_rot = goal_rot.inv() * actual_rot
-        orientation_error = error_rot.magnitude()
+
+        y_axis = [0, 1, 0]
+        goal_direction_vector = goal_rot.apply(y_axis)
+        actual_direction_vector = actual_rot.apply(y_axis)
+
+        orientation_error = np.arccos(
+            goal_direction_vector.dot(actual_direction_vector)
+        )
 
         # scale both position and orientation error to be within [0, 1] for
         # their expected ranges

--- a/tests/test_tasks_move_cube.py
+++ b/tests/test_tasks_move_cube.py
@@ -269,6 +269,36 @@ class TestMoveCube(unittest.TestCase):
             move_cube.evaluate_state(pose_origin, pose_both, difficulty), 0
         )
 
+    def test_evaluate_state_difficulty_4_rotation_around_y(self):
+        difficulty = 4
+        pose_origin = move_cube.Pose()
+        pose_rot_only_y = move_cube.Pose(
+            orientation=Rotation.from_euler("y", 0.42).as_quat()
+        )
+        pose_rot_without_y = move_cube.Pose(
+            orientation=Rotation.from_euler("yz", [0.0, 0.42]).as_quat()
+        )
+        pose_rot_with_y = move_cube.Pose(
+            orientation=Rotation.from_euler("yz", [0.2, 0.42]).as_quat()
+        )
+
+        # needs to be zero for exact match
+        cost = move_cube.evaluate_state(pose_origin, pose_origin, difficulty)
+        self.assertEqual(cost, 0)
+
+        cost_only_y = move_cube.evaluate_state(
+            pose_origin, pose_rot_only_y, difficulty
+        )
+        self.assertEqual(cost_only_y, 0)
+
+        cost_without_y = move_cube.evaluate_state(
+            pose_origin, pose_rot_without_y, difficulty
+        )
+        cost_with_y = move_cube.evaluate_state(
+            pose_origin, pose_rot_with_y, difficulty
+        )
+        self.assertAlmostEqual(cost_without_y, cost_with_y)
+
     def test_validate_goal(self):
         on_ground_height = move_cube._CUBOID_HALF_SIZE[2]
         yaw_rotation = Rotation.from_euler("z", 0.42).as_quat()


### PR DESCRIPTION
## Description

Ignore rotation around the long axis of the cuboid (y-axis) as the
object tracking is not so reliable on this axis.

Add a unit test to verify this.


## How I Tested

By running the unit tests.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
