### PR TITLE
GitHub: Remove specific config from black workflow

### DIFF
--- a/.github/workflows/style_checker.yml
+++ b/.github/workflows/style_checker.yml
@@ -9,5 +9,3 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@master
-        with:
-            black_args: "--check --diff --line-length=79"


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Since black is now configured via pyproject.toml, it shouldn't be
necessary anymore to set custom arguments on the GitHub workflow.


## How I Tested

- [x] By verifying that black doesn't complain on line lengths in this PR.
