### PR TITLE
Add CameraParameters.dump to save parameter file

### DIFF
--- a/python/trifinger_simulation/camera.py
+++ b/python/trifinger_simulation/camera.py
@@ -47,6 +47,42 @@ class CameraParameters(typing.NamedTuple):
             name, width, height, camera_matrix, dist_coeffs, tf_world_to_camera
         )
 
+    def dump(self, stream: typing.TextIO):
+        """Dump camera parameters in YAML format to the given output stream."""
+        # save all the data
+        calibration_data = {
+            "camera_name": self.name,
+            # make sure width and height are plain strings (not numpy.int64 or
+            # the like)
+            "image_width": int(self.width),
+            "image_height": int(self.height),
+        }
+
+        calibration_data["camera_matrix"] = {
+            "rows": 3,
+            "cols": 3,
+            "data": self.camera_matrix.flatten().tolist(),
+        }
+
+        calibration_data["distortion_coefficients"] = {
+            "rows": 1,
+            "cols": 5,
+            "data": self.distortion_coefficients.flatten().tolist(),
+        }
+
+        calibration_data["tf_world_to_camera"] = {
+            "rows": 4,
+            "cols": 4,
+            "data": self.tf_world_to_camera.flatten().tolist(),
+        }
+
+        yaml.dump(
+            calibration_data,
+            stream,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
 
 class BaseCamera:
     def get_image(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -11,7 +11,6 @@ from trifinger_simulation import camera as sim_camera
 TEST_DATA_DIR, _ = os.path.splitext(__file__)
 
 
-@pytest.mark.calib_data_to_matrix
 def test_calib_data_to_matrix_1x1():
     data = {
         "rows": 1,
@@ -25,7 +24,6 @@ def test_calib_data_to_matrix_1x1():
     )
 
 
-@pytest.mark.calib_data_to_matrix
 def test_calib_data_to_matrix_3x3():
     data = {
         "rows": 3,
@@ -39,7 +37,6 @@ def test_calib_data_to_matrix_3x3():
     )
 
 
-@pytest.mark.calib_data_to_matrix
 def test_calib_data_to_matrix_2x4():
     data = {
         "rows": 2,
@@ -92,6 +89,35 @@ def test_camera_parameters_load():
     )
     np.testing.assert_array_almost_equal(
         params.tf_world_to_camera, expected_tf_mat
+    )
+
+
+def test_camera_parameters_dump(tmpdir):
+    # load the test data
+    config_file = os.path.join(TEST_DATA_DIR, "camera180_full.yml")
+    with open(config_file, "r") as f:
+        params = sim_camera.CameraParameters.load(f)
+
+    # dump to a temporary file, load that again and verify that the values are
+    # the same
+    tmpfile = tmpdir.join("dump.yml")
+    with open(tmpfile, "w") as f:
+        params.dump(f)
+
+    with open(tmpfile, "r") as f:
+        params2 = sim_camera.CameraParameters.load(f)
+
+    assert params.name == params2.name
+    assert params.width == params2.width
+    assert params.height == params2.height
+    np.testing.assert_array_almost_equal(
+        params.camera_matrix, params2.camera_matrix
+    )
+    np.testing.assert_array_almost_equal(
+        params.distortion_coefficients, params2.distortion_coefficients
+    )
+    np.testing.assert_array_almost_equal(
+        params.tf_world_to_camera, params2.tf_world_to_camera
     )
 
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add a `dump` method to `CameraParameters` to store the parameters to a YAML file.


## How I Tested

By running the corresponding unit test and by using it.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
