### PR TITLE
Remove ObjectMarkers on destruction & test robot model

### DIFF
--- a/python/trifinger_simulation/visual_objects.py
+++ b/python/trifinger_simulation/visual_objects.py
@@ -112,6 +112,13 @@ class ObjectMarker:
             physicsClientId=self._pybullet_client_id,
         )
 
+    def __del__(self):
+        """Removes the cuboid from the environment."""
+        # At this point it may be that pybullet was already shut down. To avoid
+        # an error, only remove the object if the simulation is still running.
+        if pybullet.isConnected(self._pybullet_client_id):
+            pybullet.removeBody(self.body_id, self._pybullet_client_id)
+
     def set_state(self, position, orientation):
         """Set pose of the marker.
 

--- a/scripts/trifingerpro_model_test.py
+++ b/scripts/trifingerpro_model_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Script for testing the TriFingerPro model."""
+import time
+import pybullet
+from trifinger_simulation import (
+    sim_finger,
+    visual_objects,
+)
+
+
+def visualize_collisions(sim):
+    contact_points = pybullet.getContactPoints(
+        bodyA=sim.finger_id,
+        physicsClientId=sim._pybullet_client_id,
+    )
+
+    markers = []
+
+    for cp in contact_points:
+        contact_distance = cp[8]
+        if contact_distance < 0:
+            position = cp[5]
+            marker = visual_objects.CubeMarker(
+                width=0.01,
+                position=position,
+                orientation=(0, 0, 0, 1),
+                color=(1, 0, 0, 1),
+            )
+            markers.append(marker)
+
+    return markers
+
+
+def main():
+    # argparser = argparse.ArgumentParser(description=__doc__)
+    # args = argparser.parse_args()
+
+    time_step = 0.004
+
+    finger = sim_finger.SimFinger(
+        finger_type="trifingerpro",
+        time_step=time_step,
+        enable_visualization=True,
+    )
+    finger.reset_finger_positions_and_velocities([0.0, 0.9, -1.7] * 3)
+
+    markers = []
+    while True:
+        # action = finger.Action(torque=[0.3, 0.3, -0.2] * 3)
+        action = finger.Action(position=[0.0, 0.9, -1.7] * 3)
+        t = finger.append_desired_action(action)
+        finger.get_observation(t)
+
+        # delete old markers
+        for m in markers:
+            del m
+        markers = visualize_collisions(finger)
+
+        time.sleep(time_step)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
- Remove the body of an `ObjectMarker` from the simulation upon destruction of the marker instance.  This is the same as what is already done for the collision objects.
- Add a simple script to test the TriFingerPro model.


## How I Tested

By running the added script.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
