### PR TITLE
Convert to ament_python package

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -1,27 +1,30 @@
 Installation
-================
+============
 
 There are two ways to build/install this package.
 
-1. As an isolated Python package
-2. As part of a catkin workspace
+1. Using conda/pip
+2. Using colcon
 
-Install as Python package in a conda environment
-----------------------------------------------------
+
+Using conda
+-----------
 
 Prerequisites: Install Anaconda or Miniconda
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If not already done, install ``conda`` (Miniconda is sufficient).  To do so, see the
 `official documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_.
 
 We tested with conda version 4.8.3.
 
+
 Installing the trifinger_simulation package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Clone this repo and cd into it::
 
-       git clone https://gitlab.is.tue.mpg.de/robotics/trifinger_simulation.git
+       git clone https://github.com/open-dynamic-robot-initiative/trifinger_simulation
        cd trifinger_simulation
 
 2. Set up the conda env::
@@ -41,9 +44,12 @@ Installing the trifinger_simulation package
 
        python -m pip install -e .
 
-.. _`catbuild`:
 
-Build using catkin
--------------------------
+.. _`colcon`:
 
-Proper instructions for this will follow soon.
+Using colcon
+------------
+
+trifinger_simulation is part of the "ROBOT_FINGERS" project.  For build
+instructions see the `robot_fingers documentation
+<https://open-dynamic-robot-initiative.github.io/code_documentation/robot_fingers/docs/doxygen/html/md_doc_installation.html>`_

--- a/docs/simreal/simwithreal.rst
+++ b/docs/simreal/simwithreal.rst
@@ -53,7 +53,7 @@ for ``SimFinger``. Inside ``RealFinger``, the robot actually gets created like t
     In order to use the ``RealFinger`` class, you would need to install additional packages like
     `robot_interfaces`_ and `robot_fingers`_ as you can see in the example above. These packages are
     not a part of the `trifinger_simulation conda environment`_. Instructions on how to install
-    these packages will follow soon in the :ref:`catbuild` section.
+    these packages will follow soon in the :ref:`colcon` section.
 
 .. note:: 
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,20 +2,20 @@ name: trifinger_simulation
 channels:
 - conda-forge
 dependencies:
-- python=3.6.9
+- python=3.8.5
 - numpy==1.19.1
 - pinocchio==2.4.7
 - pip==20.1.1
 - pip:
-  - pybullet==2.8.4
-  - gym==0.17.2
+  - pybullet==3.0.8
+  - gym==0.18.0
   - opencv-python==4.2.0.34
-  - catkin-pkg==0.4.22
+  - pyyaml==5.3.1
     # the packages below are required to run the example (training with ppo)
     # which we provide. if you do not wish to execute the example, you may
     # safely remove them
   - tensorflow==1.15.0
-  - pandas==0.24.2
+  - pandas==0.25.3
   - joblib==0.16.0
   - stable-baselines==2.10.0
   

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>trifinger_simulation</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>
       TriFinger Robot Simulation
   </description>
@@ -9,16 +9,14 @@
   <maintainer email="felix.widmaier@tue.mpg.de">Felix Widmaier</maintainer>
   <license>BSD 3-Clause</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <build_depend>mpi_cmake_modules</build_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>robot_properties_fingers</exec_depend>
 
-  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
-      <build_type>ament_cmake</build_type>
+      <build_type>ament_python</build_type>
   </export>
 </package>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/trifinger_simulation
+[install]
+install-scripts=$base/lib/trifinger_simulation

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,75 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+import os
+from setuptools import setup
 
-d = generate_distutils_setup(
+package_name = "trifinger_simulation"
+
+
+def find_package_data(base_dir, data_dir):
+    """Get list of all files in base_dir/data_dir, relative to base_dir."""
+    paths = []
+    for (path, directories, filenames) in os.walk(
+        os.path.join(base_dir, data_dir)
+    ):
+        for filename in filenames:
+            paths.append(
+                os.path.relpath(os.path.join(path, filename), base_dir)
+            )
+    return paths
+
+
+setup(
+    name=package_name,
+    version="1.1.0",
     packages=[
-        "trifinger_simulation",
-        "trifinger_simulation.gym_wrapper",
-        "trifinger_simulation.gym_wrapper.envs",
+        package_name,
+        package_name + ".gym_wrapper",
+        package_name + ".gym_wrapper.envs",
+        package_name + ".tasks",
     ],
     package_dir={"": "python"},
-    package_data={
-        "": [
-            "robot_properties_fingers/meshes/*",
-            "robot_properties_fingers/urdf/*",
-        ]
-    },
+    data_files=[
+        (
+            "share/ament_index/resource_index/packages",
+            ["resource/" + package_name],
+        ),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=False,  # <- TODO Could this be True?
+    maintainer="Felix Widmaier",
+    maintainer_email="felix.widmaier@tue.mpg.de",
+    description="TriFinger Robot Simulation",
+    license="BSD 3-Clause",
+    tests_require=["pytest"],
+    # entry_points={
+    #    'console_scripts': [
+    #            'my_node = my_py_pkg.my_node:main'
+    #    ],
+    #  },
+    # TODO: use entry_points instead of scripts to get rid of the .py extension
+    # on the executables.
     scripts=[
+        "demos/demo_cameras.py",
+        "demos/demo_control.py",
+        "demos/demo_inverse_kinematics.py",
+        "demos/demo_load_gym_env.py",
+        "demos/demo_plain_torque_control.py",
+        "demos/demo_random_policy.py",
+        "demos/demo_trifinger_platform.py",
+        "scripts/check_position_control_accuracy.py",
+        "scripts/evaluate_policy.py",
+        "scripts/profiling.py",
         "scripts/replay_action_log.py",
         "scripts/rrc_evaluate",
         "scripts/run_evaluate_policy_all_levels.py",
         "scripts/run_replay_all_levels.py",
     ],
+    package_data={
+        "": (
+            find_package_data("python/trifinger_simulation", "data")
+            + find_package_data(
+                "python/trifinger_simulation", "robot_properties_fingers"
+            )
+        )
+    },
 )
-
-setup(**d)


### PR DESCRIPTION
## Description

There is no C++ code here anymore, so converting this into a pure Python
package should make it easier to use it stand-alone, e.g. with conda.

Also push versions in environment.yml to match with the recent Singularity image and update installation instructions 

## How I Tested

By trying both the colon workspace and the conda environment, running one of the demo scripts.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
