### PR TITLE
Set default time_step to 0.001 and tune PD gains for FingerPro

### DIFF
--- a/demos/demo_control.py
+++ b/demos/demo_control.py
@@ -31,7 +31,7 @@ def main():
         help="Specify a valid finger type",
     )
     args = argparser.parse_args()
-    time_step = 0.004
+    time_step = 0.001
 
     finger = sim_finger.SimFinger(
         finger_type=args.finger_type,

--- a/demos/demo_inverse_kinematics.py
+++ b/demos/demo_inverse_kinematics.py
@@ -7,7 +7,7 @@ import trifinger_simulation
 
 
 def main():
-    time_step = 0.004
+    time_step = 0.001
     finger = trifinger_simulation.SimFinger(
         finger_type="trifingerpro",
         time_step=time_step,

--- a/python/trifinger_simulation/finger_types_data.py
+++ b/python/trifinger_simulation/finger_types_data.py
@@ -16,6 +16,7 @@ finger_types_data = {
     "trifingerone": FingerTypesDataFormat("trifinger.urdf", 3),
     "fingeredu": FingerTypesDataFormat("edu/fingeredu.urdf", 1),
     "trifingeredu": FingerTypesDataFormat("edu/trifingeredu.urdf", 3),
+    "fingerpro": FingerTypesDataFormat("pro/fingerpro.urdf", 1),
     "trifingerpro": FingerTypesDataFormat("pro/trifingerpro.urdf", 3),
 }
 

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -50,7 +50,7 @@ class SimFinger:
     def __init__(
         self,
         finger_type,
-        time_step=0.004,
+        time_step=0.001,
         enable_visualization=False,
         robot_position_offset=(0, 0, 0),
     ):
@@ -63,7 +63,7 @@ class SimFinger:
                 types.
             time_step (float): Time (in seconds) between two simulation steps.
                 Don't set this to be larger than 1/60.  The gains etc. are set
-                according to a time_step of 0.004 s.
+                according to a time_step of 0.001 s.
             enable_visualization (bool): Set this to 'True' for a GUI interface
                 to the simulation.
             robot_position_offset: Position offset with which the robot is

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -37,6 +37,16 @@ class SimFinger:
     pyBullet simulation environment for the single and the tri-finger robots.
     """
 
+    #: The kp gains for the pd control of the finger(s). Note, this depends
+    #: on the simulation step size and has been set for a simulation rate
+    #: of 250 Hz.
+    position_gains: typing.Sequence[float]
+
+    #: The kd gains for the pd control of the finger(s). Note, this depends
+    #: on the simulation step size and has been set for a simulation rate
+    #: of 250 Hz.
+    velocity_gains: typing.Sequence[float]
+
     def __init__(
         self,
         finger_type,
@@ -67,19 +77,7 @@ class SimFinger:
 
         self.time_step_s = time_step
 
-        #: The kp gains for the pd control of the finger(s). Note, this depends
-        #: on the simulation step size and has been set for a simulation rate
-        #: of 250 Hz.
-        self.position_gains = np.array(
-            [10.0, 10.0, 10.0] * self.number_of_fingers
-        )
-
-        #: The kd gains for the pd control of the finger(s). Note, this depends
-        #: on the simulation step size and has been set for a simulation rate
-        #: of 250 Hz.
-        self.velocity_gains = np.array(
-            [0.1, 0.3, 0.001] * self.number_of_fingers
-        )
+        self.__set_default_pd_gains()
 
         #: The kd gains used for damping the joint motor velocities during the
         #: safety torque check on the joint motors.
@@ -814,3 +812,20 @@ class SimFinger:
             )
         else:
             raise ValueError("Invalid finger type '%s'" % self.finger_type)
+
+    def __set_default_pd_gains(self):
+        """Set the default PD gains depending on the finger type."""
+        if self.finger_type in ["fingerpro", "trifingerpro"]:
+            self.position_gains = np.array(
+                [15.0, 15.0, 9.0] * self.number_of_fingers
+            )
+            self.velocity_gains = np.array(
+                [0.5, 1.0, 0.5] * self.number_of_fingers
+            )
+        else:
+            self.position_gains = np.array(
+                [10.0, 10.0, 10.0] * self.number_of_fingers
+            )
+            self.velocity_gains = np.array(
+                [0.1, 0.3, 0.001] * self.number_of_fingers
+            )

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import numpy as np
-import warnings
 import typing
 
 import pybullet
@@ -14,7 +13,7 @@ from trifinger_simulation import pinocchio_utils
 from trifinger_simulation import finger_types_data
 
 
-def int_to_rgba(color: int, alpha: int = 0xFF) -> typing.Tuple[float]:
+def int_to_rgba(color: int, alpha: int = 0xFF) -> typing.Tuple[float, ...]:
     """Convert an 24-bit integer to an rgba tuple.
 
     Converts color given as a single 24-bit integer (e.g. a hex value 0xFF0011)
@@ -114,8 +113,9 @@ class SimFinger:
         """
         Fill in the fields of the action structure.
 
-        This is a factory go create an :class:`~trifinger_simulation.action.Action`
-        instance with proper default values, depending on the finger type.
+        This is a factory go create an
+        :class:`~trifinger_simulation.action.Action` instance with proper
+        default values, depending on the finger type.
 
         Args:
             torque (array): Torques to apply to the joints.  Defaults to

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -34,19 +34,7 @@ def int_to_rgba(color: int, alpha: int = 0xFF) -> typing.Tuple[float, ...]:
 
 class SimFinger:
     """
-    A simulation environment for the single and the tri-finger robots.
-    This environment is based on PyBullet, the official Python wrapper around
-    the Bullet-C API.
-
-    Attributes:
-        finger_type (string): Name of the finger type.  Use
-                :meth:`get_valid_finger_types` to get a list of all supported
-                types.
-        time_step (float): Time (in seconds) between two simulation steps.
-            Don't set this to be larger than 1/60.  The gains etc. are set
-            according to a time_step of 0.004 s.
-        enable_visualization (bool): Set this to 'True' for a GUI interface
-            to the simulation.
+    pyBullet simulation environment for the single and the tri-finger robots.
     """
 
     def __init__(

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -732,7 +732,7 @@ class SimFinger:
         def mesh_path(filename):
             return os.path.join(self.robot_properties_path, "meshes", filename)
 
-        if self.finger_type in ["fingerone", "fingeredu"]:
+        if self.finger_type in ["fingerone", "fingeredu", "fingerpro"]:
             collision_objects.import_mesh(
                 mesh_path("Stage_simplified.stl"),
                 position=[0, 0, 0],

--- a/python/trifinger_simulation/trifinger_platform.py
+++ b/python/trifinger_simulation/trifinger_platform.py
@@ -102,7 +102,7 @@ class TriFingerPlatform:
         initial_robot_position=None,
         initial_object_pose=None,
         enable_cameras=False,
-        time_step_s=0.004,
+        time_step_s=0.001,
     ):
         """Initialize.
 

--- a/scripts/check_position_control_accuracy.py
+++ b/scripts/check_position_control_accuracy.py
@@ -13,7 +13,7 @@ from trifinger_simulation import sim_finger, sample
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--time-step", "-t", type=float, required=True)
-    parser.add_argument("--plot", action="store_true")
+    parser.add_argument("--plot", type=int)
     args = parser.parse_args()
 
     time_step = args.time_step
@@ -21,7 +21,9 @@ if __name__ == "__main__":
     finger = sim_finger.SimFinger(
         time_step=time_step,
         enable_visualization=True,
-        finger_type="fingerone",
+        finger_type="fingerpro",
+        # spawn robot higher up to avoid collisions with the table
+        robot_position_offset=(0, 0, 0.5),
     )
     # set the finger to a reasonable start position
     finger.reset_finger_positions_and_velocities([0, -0.7, -1.5])
@@ -29,12 +31,17 @@ if __name__ == "__main__":
     errors = []
     for _ in range(100):
         target_position = np.array(
-            sample.random_joint_positions(number_of_fingers=1)
+            sample.random_joint_positions(
+                number_of_fingers=1,
+                lower_bounds=[-0.33, 0.0, -2.7],
+                upper_bounds=[1.0, 1.57, 0.0],
+            )
         )
 
         action = finger.Action(position=target_position)
         positions = []
-        for _ in range(500):
+        steps = 1000
+        for _ in range(steps):
             t = finger.append_desired_action(action)
             observation = finger.get_observation(t)
             positions.append(observation.position)
@@ -42,12 +49,15 @@ if __name__ == "__main__":
         observation = finger.get_observation(t)
         error = np.abs(observation.position - target_position)
         errors.append(error)
-        print("Position error: {}".format(error))
+        # print("Target position: {}".format(target_position))
+        print("Position error:  {}".format(error))
 
-        if args.plot:
+        if args.plot is not None:
+            target_line = target_position[args.plot]
             positions = np.vstack(positions)
-            plt.plot(positions[:, 1], "b")
-            plt.hlines(target_position[1], 0, 500)
+            plt.plot(positions[:, args.plot], "b")
+            plt.hlines(target_line, 0, steps)
+            plt.axis((None, None, target_line - 0.1, target_line + 0.1))
             plt.show()
 
     print("==============================================================")

--- a/scripts/playback_data.py
+++ b/scripts/playback_data.py
@@ -17,9 +17,7 @@ from trifinger_simulation import finger_types_data
 
 
 def main_finger(finger_type, data_file):
-    finger = SimFinger(
-        time_step=0.004, enable_visualization=True, finger_type=finger_type
-    )
+    finger = SimFinger(enable_visualization=True, finger_type=finger_type)
     goal_marker = visual_objects.Marker(number_of_goals=1)
 
     def reset_finger(joint_position):
@@ -92,9 +90,7 @@ def trifinger_goal_space_transforms(finger_type, data):
 
 def main_trifinger(finger_type, data_file_0, data_file_120, data_file_240):
 
-    finger = SimFinger(
-        time_step=0.004, enable_visualization=True, finger_type=finger_type
-    )
+    finger = SimFinger(enable_visualization=True, finger_type=finger_type)
     goal_marker = visual_objects.Marker(number_of_goals=3)
 
     def reset_finger(joint_position):

--- a/scripts/profiling.py
+++ b/scripts/profiling.py
@@ -14,7 +14,6 @@ finger_names = ["trifingerone", "trifingeredu", "trifingerpro"]
 def execute_random_motion(*, finger_name, nb_timesteps, enable_visualization):
     finger = SimFinger(
         finger_type=finger_name,
-        time_step=0.004,
         enable_visualization=enable_visualization,
     )
     cube = collision_objects.Block()

--- a/scripts/trifingerpro_model_test.py
+++ b/scripts/trifingerpro_model_test.py
@@ -35,7 +35,7 @@ def main():
     # argparser = argparse.ArgumentParser(description=__doc__)
     # args = argparser.parse_args()
 
-    time_step = 0.004
+    time_step = 0.001
 
     finger = sim_finger.SimFinger(
         finger_type="trifingerpro",


### PR DESCRIPTION
## Description

- To avoid confusion for users that are switching between simulation and real robot, set the default step size of the simulation to 0.001 to match the real robot.
- Use different PD gains based on the finger type and tune the gains for (Tri)FingerPro.  The gains are tuned manually using check_position_control_accuracy.py (which has been modified a bit for this).  With these gains a mean error of [0.0095 0.01435 0.0039] is achieved when using a step size of 0.001.
- To make tuning gains for TriFingerPro easier, enable the use of a single FingerPro in the Simulation.
- To make tuning easier (but also because it might be useful in other cases), add an argument `robot_position_offset` to `SimFinger` which allows changing the robot position (e.g. to modify the distance between fingers and table).


## How I Tested

Mostly by running `check_position_control_accuracy.py`.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
