### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -1,48 +1,83 @@
 Installation
 ============
 
-There are two ways to build/install this package.
+There are two ways to build/install this package:
 
-1. Using conda/pip
+1. Stand-alone installation using pip
 2. Using colcon
 
 
-Using conda
------------
+Stand-alone installation using pip
+----------------------------------
 
-Prerequisites: Install Anaconda or Miniconda
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+
+   We are developing for Python 3.8.  Other versions may work as well but are
+   not officially supported.
+
+
+Get the source from GitHub::
+
+    $ git clone https://github.com/open-dynamic-robot-initiative/trifinger_simulation
+
+
+To avoid version conflicts with other packages on your system, it is
+recommended to install the package in an isolated environment like venv or
+conda.
+
+
+Using venv
+~~~~~~~~~~
+
+You may first need to install ``venv``.  E.g. on Ubuntu: ``sudo apt install
+python3-venv``.  Then create a new environment and install the package and its
+dependencies
+
+.. code-block:: bash
+
+    $ python3 -m venv ~/venv_trifinger_simulation
+    $ . ~/venv_trifinger_simulation/bin/activate
+
+    $ pip install --upgrade pip  # make sure the latest version of pip is used
+
+    $ cd trifinger_simulation
+    $ pip install -r requirements.txt
+    $ pip install .
+
+
+Using conda
+~~~~~~~~~~~
 
 If not already done, install ``conda`` (Miniconda is sufficient).  To do so, see the
 `official documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_.
 
 We tested with conda version 4.8.3.
 
+1. Create the conda environment::
 
-Installing the trifinger_simulation package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       $ conda env create -f environment.yml
 
-1. Clone this repo and cd into it::
+2. Activate the environment (you may have to do this in a new terminal)::
 
-       git clone https://github.com/open-dynamic-robot-initiative/trifinger_simulation
-       cd trifinger_simulation
+       $ conda activate trifinger_simulation
 
-2. Set up the conda env::
+3. Install the trifinger_simulation package::
 
-       conda env create -f environment.yml
+       $ cd trifinger_simulation
+       $ python3 -m pip install .
 
-   Note that the environment.yml contains some packages (such as
-   stable-baselines and tensorflow) which are only required for running the
-   examples we provide. If you do not wish to install them, you can safely remove
-   them, see comments in the environment.yml file.
 
-3. Activate the conda env (you might have to start a new terminal)::
+Test Installation
+~~~~~~~~~~~~~~~~~
 
-       conda activate trifinger_simulation
+You can test the installation by running the unit tests::
 
-4. Install the trifinger_simulation package::
+    $ python3 -m pytest tests/
 
-       python -m pip install -e .
+or by running one of the demos::
+
+    $ python3 demos/demo_trifinger_platform.py
+
 
 
 .. _`colcon`:
@@ -52,4 +87,4 @@ Using colcon
 
 trifinger_simulation is part of the "ROBOT_FINGERS" project.  For build
 instructions see the `robot_fingers documentation
-<https://open-dynamic-robot-initiative.github.io/code_documentation/robot_fingers/docs/doxygen/html/md_doc_installation.html>`_
+<http://people.tuebingen.mpg.de/mpi-is-software/robotfingers/docs/robot_fingers/doc/installation.html>`_

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,6 @@ channels:
 - conda-forge
 dependencies:
 - python=3.8.5
-- numpy==1.19.1
-- pinocchio==2.4.7
-- pytest==6.2.3
-- pip==20.1.1
+- pip==21.0
 - pip:
-  - pybullet==3.0.8
-  - gym==0.18.0
-  - opencv-python==4.2.0.34
-  - pyyaml==5.3.1
+  - -r file:requirements.txt

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>trifinger_simulation</name>
-  <version>1.1.0</version>
+  <version>1.2.1</version>
   <description>
       TriFinger Robot Simulation
   </description>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+
 [tool.black]
 line-length = 79
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+gym==0.18.0
+numpy==1.19.5; python_version<"3.8"
+numpy==1.20.3; python_version>="3.8"
+opencv-python==4.2.0.34
+pin==2.6.0
+pybullet==3.0.8
+pytest==6.2.3
+pyyaml==5.3.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def find_package_data(base_dir, data_dir):
 
 setup(
     name=package_name,
-    version="1.2.0",
+    version="1.2.1",
     packages=[
         package_name,
         package_name + ".gym_wrapper",
@@ -36,12 +36,19 @@ setup(
         ),
         ("share/" + package_name, ["package.xml"]),
     ],
-    install_requires=["setuptools"],
     zip_safe=False,  # <- TODO Could this be True?
     maintainer="Felix Widmaier",
     maintainer_email="felix.widmaier@tue.mpg.de",
     description="TriFinger Robot Simulation",
     license="BSD 3-Clause",
+    install_requires=[
+        "numpy >=1.19.1",
+        "pin >=2.4.7",  # pinocchio
+        "pybullet >=3.0.8",
+        "gym >=0.18.0",
+        "opencv-python >=4.2.0.34",
+        "pyyaml >=5.3.1",
+    ],
     tests_require=["pytest"],
     # entry_points={
     #    'console_scripts': [


### PR DESCRIPTION
## Description

With all the dependencies specified in the setup.py, the package can be
installed directly with pip, so there is no need for conda anymore.

Addresses part of #57 

## How I Tested

By installing it via `pip install .` and testing the installation by running some of the demos.

I did not yet verify if this change causes any trouble when still using conda (which should still be supported, even if not needed anymore).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
