### PR TITLE
fix: Flipped dimensions when cropping distorted image

### DIFF
--- a/python/trifinger_simulation/camera.py
+++ b/python/trifinger_simulation/camera.py
@@ -368,7 +368,7 @@ class CalibratedCamera(BaseCamera):
         in_image_idx = np.all(
             np.logical_and(
                 (0, 0) <= distorted_points,
-                distorted_points < (self._render_width, self._render_height),
+                distorted_points < (self._render_height, self._render_width),
             ),
             axis=1,
         )


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Height and width were mixed up when cropping the distorted points to the image area, resulting in some part of the image missing when having a non-square aspect ratio.

### Before
![Screenshot_20210623_135735](https://user-images.githubusercontent.com/9333121/123092811-30107800-d42b-11eb-88d7-5112338b3b95.png)


### After
![Screenshot_20210623_135646](https://user-images.githubusercontent.com/9333121/123092835-36065900-d42b-11eb-8cd2-b020c8dc2f84.png)



## How I Tested

using demo_cameras.py (see screenshot above)


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
