### PR TITLE
Change camera pose in GUI and colours of stages

### DIFF
--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -741,10 +741,12 @@ class SimFinger:
             return os.path.join(self.robot_properties_path, "meshes", filename)
 
         if self.finger_type in ["fingerone", "fingeredu", "fingerpro"]:
+            table_colour = (0.73, 0.68, 0.72, 1.0)
             collision_objects.import_mesh(
                 mesh_path("Stage_simplified.stl"),
                 position=[0, 0, 0],
                 is_concave=True,
+                color_rgba=table_colour,
                 pybullet_client_id=self._pybullet_client_id,
             )
 

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -804,7 +804,7 @@ class SimFinger:
 
         elif self.finger_type == "trifingeredu":
             table_colour = (0.95, 0.95, 0.95, 1.0)
-            high_border_colour = (0.95, 0.95, 0.95, 1.0)
+            high_border_colour = (0.95, 0.95, 0.95, 0.5)
 
             # use a simple cuboid for the table
             self._table_id = collision_objects.Cuboid(

--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -582,6 +582,17 @@ class SimFinger:
             self.time_step_s, physicsClientId=self._pybullet_client_id
         )
 
+        # change initial camera pose to something that fits better for the
+        # (Tri)Finger robots (mostly moves it closer to the robot as the
+        # default).
+        pybullet.resetDebugVisualizerCamera(
+            cameraDistance=1.0,
+            cameraYaw=100.0,
+            cameraPitch=-30.0,
+            cameraTargetPosition=(0, 0, 0.2),
+            physicsClientId=self._pybullet_client_id,
+        )
+
         pybullet.loadURDF(
             "plane_transparent.urdf",
             [0, 0, -0.01],


### PR DESCRIPTION
## Description
Change initial camera pose and colours of stages for single finger and TriFingerEdu.  See individual commits for details.


## How I Tested

By running the simulation with different finger types.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
