### PR TITLE
Add GitHub Action to block fixup commit

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Fixup/squash commits (`git commit --fixup`/`git commit --squash`) can be
very useful during development and code review but they should be
cleaned up before merging into master.

This GitHub action checks for existence of such commits, so merging can
be blocked automatically.


## How I Tested

In this pull request.