### PR TITLE
Use np.core.umath.clip instead of np.clip

### DIFF
--- a/python/trifinger_simulation/sim_finger.py
+++ b/python/trifinger_simulation/sim_finger.py
@@ -448,6 +448,48 @@ class SimFinger:
             physicsClientId=self._pybullet_client_id,
         )
 
+    @staticmethod
+    def _sanitise_torques(
+        desired_torques: typing.Sequence[float],
+        max_torque: float,
+        safety_kd: float,
+        joint_velocities: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Perform a check on the torques being sent to be applied to
+        the motors so that they do not exceed the safety torque limit
+
+        Note: This static method exists for easier unit testing.
+
+        Args:
+            desired_torques: The torques desired to be applied to the motors.
+            max_torque: The maximum absolute joint torque that is allowed.
+            safety_kd: Kd gain for the velocity damping.  Set to zero to
+                disable the damping.
+            joint_velocities: Current joint velocities (used for the velocity
+                damping).
+
+        Returns:
+            The torques that can safely be applied to the joints.
+        """
+        # clip desired torque to allowed range
+        applied_torques = np.clip(
+            desired_torques,
+            -max_torque,
+            +max_torque,
+        )
+
+        # apply velocity damping and clip again to make sure we stay in the
+        # valid range
+        applied_torques -= safety_kd * joint_velocities
+        applied_torques = np.clip(
+            applied_torques,
+            -max_torque,
+            +max_torque,
+        )
+
+        return applied_torques
+
     def __safety_check_torques(
         self, desired_torques: typing.Sequence[float]
     ) -> np.ndarray:
@@ -462,12 +504,6 @@ class SimFinger:
             The torques that can be actually applied to the motors (and will be
             applied)
         """
-        applied_torques = np.clip(
-            np.asarray(desired_torques),
-            -self.max_motor_torque,
-            +self.max_motor_torque,
-        )
-
         current_joint_states = pybullet.getJointStates(
             self.finger_id,
             self.pybullet_joint_indices,
@@ -476,15 +512,13 @@ class SimFinger:
         current_velocity = np.array(
             [joint[1] for joint in current_joint_states]
         )
-        applied_torques -= self.safety_kd * current_velocity
 
-        applied_torques = np.clip(
-            np.asarray(applied_torques),
-            -self.max_motor_torque,
-            +self.max_motor_torque,
+        return self._sanitise_torques(
+            desired_torques,
+            self.max_motor_torque,
+            self.safety_kd,
+            current_velocity,
         )
-
-        return applied_torques
 
     def __compute_pd_control_torques(
         self,

--- a/tests/test_sim_finger.py
+++ b/tests/test_sim_finger.py
@@ -1,4 +1,6 @@
-from trifinger_simulation.sim_finger import int_to_rgba
+from trifinger_simulation.sim_finger import int_to_rgba, SimFinger
+
+import numpy as np
 
 
 def test_int_to_rgba():
@@ -12,3 +14,47 @@ def test_int_to_rgba():
         102 / 255,
         42 / 255,
     )
+
+
+def test_SimFinger_sanitise_torqes():
+    max_torque = 0.5
+
+    # without velocity damping
+    t = SimFinger._sanitise_torques(
+        [-0.2, 0.4], max_torque, 0, np.array([0, 0])
+    )
+    np.testing.assert_array_equal(t, [-0.2, 0.4])
+
+    t = SimFinger._sanitise_torques(
+        [-1.2, 0.4], max_torque, 0, np.array([0, 0])
+    )
+    np.testing.assert_array_equal(t, [-0.5, 0.4])
+
+    t = SimFinger._sanitise_torques(
+        [-0.2, 0.6], max_torque, 0, np.array([0, 0])
+    )
+    np.testing.assert_array_equal(t, [-0.2, 0.5])
+
+    t = SimFinger._sanitise_torques(
+        [-0.8, 0.6], max_torque, 0, np.array([0, 0])
+    )
+    np.testing.assert_array_equal(t, [-0.5, 0.5])
+
+    # with velocity damping
+    t = SimFinger._sanitise_torques(
+        [0, 0], max_torque, 0.2, np.array([1, -0.5])
+    )
+    np.testing.assert_array_almost_equal(t, [-0.2, 0.1])
+
+    t = SimFinger._sanitise_torques([0, 0], max_torque, 1, np.array([1, -0.6]))
+    np.testing.assert_array_almost_equal(t, [-0.5, 0.5])
+
+    t = SimFinger._sanitise_torques(
+        [0.1, 0.2], max_torque, 0.2, np.array([1, -0.5])
+    )
+    np.testing.assert_array_almost_equal(t, [-0.1, 0.3])
+
+    t = SimFinger._sanitise_torques(
+        [1, -1], max_torque, 0.2, np.array([1, -0.5])
+    )
+    np.testing.assert_array_almost_equal(t, [0.3, -0.4])


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

As pointed out in https://github.com/rr-learning/CausalWorld/issues/101 `np.clip` got significantly slower in NumPy versions >=1.17.
The best workaround currently seems to be to use the internal `np.core.umath.clip` instead (see https://github.com/numpy/numpy/issues/14281).
`np.core.umath.clip` does not exist in versions <1.17 so in this case we fall back to `np.clip` (which is okay because in these versions `np.clip` was still good).

At least on my laptop, this change speeds up the simulation by around 13%.

I also moved the computation of the safe torque to a static method that doesn't depend on any internal state, so unit-testing is easier.

## How I Tested
Through the new unit test and by running some demos.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
