### PR TITLE
chore: Update documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,16 +23,18 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - uses: actions/checkout@v2
       with:
         path: trifinger_simulation
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-    - name: Build and Commit
-      uses: sphinx-notes/pages@1.0
+    - name: Build and commit documentation
+      uses: sphinx-notes/pages@2.0
       with:
         repository_path: trifinger_simulation
-        documentation_path: docs
+        requirements_path: docs/requirements.txt
     - name: Push changes
       uses: ad-m/github-push-action@v0.6.0
       with:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,3 +83,8 @@ please cite this repository and also the corresponding paper:
 .. _trifinger_simulation: https://github.com/open-dynamic-robot-initiative/trifinger_simulation
 .. _`TriFinger project website`: https://sites.google.com/view/trifinger
 .. _paper: https://arxiv.org/abs/2008.03596
+
+
+----
+
+Last rebuild of this documentation: |today|

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+-r ../requirements.txt


### PR DESCRIPTION
## Description
- Use recently released version 2 of sphinx-notes/pages.
- Include package requirements in the doc requirements (otherwise build
  fails)
- Add current date at the bottom of the start page, so it is easier to
  verify if the documentation was updated.
