### PR TITLE
Set initial position based on finger type

### DIFF
--- a/demos/demo_plain_torque_control.py
+++ b/demos/demo_plain_torque_control.py
@@ -11,8 +11,6 @@ if __name__ == "__main__":
         finger_type="fingerone",
         enable_visualization=True,
     )
-    # set the finger to a reasonable start position
-    finger.reset_finger_positions_and_velocities([0, -0.7, -1.5])
 
     # Send a constant torque to the joints, switching direction periodically.
     torque = np.array([0.0, 0.3, 0.3])

--- a/scripts/check_position_control_accuracy.py
+++ b/scripts/check_position_control_accuracy.py
@@ -25,8 +25,6 @@ if __name__ == "__main__":
         # spawn robot higher up to avoid collisions with the table
         robot_position_offset=(0, 0, 0.5),
     )
-    # set the finger to a reasonable start position
-    finger.reset_finger_positions_and_velocities([0, -0.7, -1.5])
 
     errors = []
     for _ in range(100):

--- a/scripts/trifingerpro_model_test.py
+++ b/scripts/trifingerpro_model_test.py
@@ -42,7 +42,6 @@ def main():
         time_step=time_step,
         enable_visualization=True,
     )
-    finger.reset_finger_positions_and_velocities([0.0, 0.9, -1.7] * 3)
 
     markers = []
     while True:

--- a/trifinger_simulation/finger_types_data.py
+++ b/trifinger_simulation/finger_types_data.py
@@ -8,17 +8,47 @@ class FingerTypesDataFormat(typing.NamedTuple):
     number of fingers.
     """
 
+    #: Path to the URDF file (relative to the URDF base directory)
     urdf_file: str
+
+    #: Number of fingers the robot has.
     number_of_fingers: int
+
+    #: Initial joint positions.
+    initial_joint_positions: typing.Sequence[float]
 
 
 finger_types_data = {
-    "fingerone": FingerTypesDataFormat("finger.urdf", 1),
-    "trifingerone": FingerTypesDataFormat("trifinger.urdf", 3),
-    "fingeredu": FingerTypesDataFormat("edu/fingeredu.urdf", 1),
-    "trifingeredu": FingerTypesDataFormat("edu/trifingeredu.urdf", 3),
-    "fingerpro": FingerTypesDataFormat("pro/fingerpro.urdf", 1),
-    "trifingerpro": FingerTypesDataFormat("pro/trifingerpro.urdf", 3),
+    "fingerone": FingerTypesDataFormat(
+        urdf_file="finger.urdf",
+        number_of_fingers=1,
+        initial_joint_positions=[0, 0, 0],
+    ),
+    "trifingerone": FingerTypesDataFormat(
+        urdf_file="trifinger.urdf",
+        number_of_fingers=3,
+        initial_joint_positions=[0, -0.9, -1.7] * 3,
+    ),
+    "fingeredu": FingerTypesDataFormat(
+        urdf_file="edu/fingeredu.urdf",
+        number_of_fingers=1,
+        initial_joint_positions=[0, 0.9, -1.7],
+    ),
+    "trifingeredu": FingerTypesDataFormat(
+        urdf_file="edu/trifingeredu.urdf",
+        number_of_fingers=3,
+        initial_joint_positions=[0, 0.9, -1.7] * 3,
+    ),
+    "fingerpro": FingerTypesDataFormat(
+        urdf_file="pro/fingerpro.urdf",
+        number_of_fingers=1,
+        initial_joint_positions=[0, 0.9, -1.7],
+    ),
+    "trifingerpro": FingerTypesDataFormat(
+        urdf_file="pro/trifingerpro.urdf",
+        number_of_fingers=3,
+        initial_joint_positions=[0, 0.9, -1.7] * 3,
+    ),
 }
 
 
@@ -82,7 +112,24 @@ def get_number_of_fingers(name: str) -> int:
         Number of fingers.
 
     Raises:
-        ValueError: If *key* is not a valid finger type.
+        ValueError: If *name* is not a valid finger type.
     """
     check_finger_type(name)
     return finger_types_data[name].number_of_fingers
+
+
+def get_initial_joint_positions(name: str) -> typing.Sequence[float]:
+    """
+    Get initial joint positions of the specified finger type
+
+    Args:
+        name: Name of the finger type.
+
+    Returns:
+        Angular joint positions.
+
+    Raises:
+        ValueError: If *name* is not a valid finger type.
+    """
+    check_finger_type(name)
+    return finger_types_data[name].initial_joint_positions

--- a/trifinger_simulation/sim_finger.py
+++ b/trifinger_simulation/sim_finger.py
@@ -671,6 +671,11 @@ class SimFinger:
         self.__load_stage()
         self.__disable_pybullet_velocity_control()
 
+        # set initial position based on robot type
+        self.reset_finger_positions_and_velocities(
+            finger_types_data.get_initial_joint_positions(self.finger_type)
+        )
+
     def __set_pybullet_params(self):
         """
         To change properties of the robot such as its mass, friction, damping,


### PR DESCRIPTION
## Description

For each finger type specify its default initial position in the
finger_types_data module (using the same values as in the configuration
of the real robots).
This is ensures that the fingers are not stuck in the ground upon
initialisation, which is the case for some of the robots if initialised
to all-zero positions.

Remove redundant initialisation from some of the scripts.

## How I Tested

By running unit tests and some demo scripts.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
