### PR TITLE
Add delay between when camera observation is captured and when it is provided

### DIFF
--- a/tests/test_trifinger_platform.py
+++ b/tests/test_trifinger_platform.py
@@ -13,10 +13,16 @@ def test_timestamps():
     # ensure the camera frame rate is set to 10 Hz
     assert platform.camera_rate_fps == 10
 
+    # ensure that delay between when camera observation is taken and
+    # when it is provided is one camera update interval
+    assert platform.camera_obs_delay == 1
+
     # compute camera update step interval based on configured rates
     camera_update_step_interval = (
         1 / platform.camera_rate_fps
     ) / platform._time_step
+    # delay between image capture and camera observation in seconds
+    camera_obs_delay_s = platform.camera_obs_delay / platform.camera_rate_fps
     # robot time step in milliseconds
     time_step_ms = platform._time_step * 1000
 
@@ -59,9 +65,9 @@ def test_timestamps():
     assert nth_stamp_ms > second_stamp_ms
 
     camera_obs = platform.get_camera_observation(t)
-    assert nth_stamp_s == camera_obs.cameras[0].timestamp
-    assert nth_stamp_s == camera_obs.cameras[1].timestamp
-    assert nth_stamp_s == camera_obs.cameras[2].timestamp
+    assert nth_stamp_s == camera_obs.cameras[0].timestamp + camera_obs_delay_s
+    assert nth_stamp_s == camera_obs.cameras[1].timestamp + camera_obs_delay_s
+    assert nth_stamp_s == camera_obs.cameras[2].timestamp + camera_obs_delay_s
 
 
 def test_get_camera_observation_timeindex():

--- a/trifinger_simulation/trifinger_platform.py
+++ b/trifinger_simulation/trifinger_platform.py
@@ -166,8 +166,9 @@ class TriFingerPlatform:
             object_type:  Which type of object to load.  This also influences
                 some other aspects: When using the cube, the camera observation
                 will contain an attribute ``object_pose``.
-            camera_obs_delay: Delay in camera update intervals between when the camera
-                observation is determined and when it is provided.
+            camera_obs_delay: Delay between when the camera observation
+                is determined and when it is provided (in camera update
+                intervals).
         """
         #: Camera rate in frames per second.  Observations of camera and
         #: object pose will only be updated with this rate.
@@ -184,7 +185,7 @@ class TriFingerPlatform:
 
         # Deque storing last object poses recorded camera update step
         # interval apart. The oldest one will be provided in the observation.
-        self._camera_obs_delay = camera_obs_delay
+        self.camera_obs_delay = camera_obs_delay
         self._camera_obs_history = deque(maxlen=camera_obs_delay + 1)
 
         # Initialize robot, object and cameras
@@ -271,9 +272,7 @@ class TriFingerPlatform:
         """Get camera_obs delayed by camera_obs_delay."""
         # Go back camera_obs_delay entries in deque if possible, else
         # take oldest pose.
-        index = max(
-            -len(self._camera_obs_history), -self._camera_obs_delay - 1
-        )
+        index = max(-len(self._camera_obs_history), -self.camera_obs_delay - 1)
         return self._camera_obs_history[index]
 
     def append_desired_action(self, action):

--- a/trifinger_simulation/trifinger_platform.py
+++ b/trifinger_simulation/trifinger_platform.py
@@ -186,7 +186,7 @@ class TriFingerPlatform:
         # Deque storing last object poses recorded camera update step
         # interval apart. The oldest one will be provided in the observation.
         self.camera_obs_delay = camera_obs_delay
-        self._camera_obs_history = deque(maxlen=camera_obs_delay + 1)
+        self._camera_obs_history = deque(maxlen=camera_obs_delay + 1)  # type: ignore
 
         # Initialize robot, object and cameras
         # ====================================


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Introduce delay between when the camera observation in TriFingerPlatform is captured and when it is provided in the observation. This reproduces the behavior on the real robot (where running object tracking requires a finite amount of time). 

The update is based on the assumption that this delay is a multiple of the interval at which the camera images are taken.

## How I Tested

[//]: # "Explain how you tested your changes"

Ran pytest.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
