### PR TITLE
Simulate delay of camera observations

### DIFF
--- a/tests/test_trifinger_platform.py
+++ b/tests/test_trifinger_platform.py
@@ -6,8 +6,10 @@ import numpy as np
 from trifinger_simulation import TriFingerPlatform
 
 
-def test_timestamps():
-    platform = TriFingerPlatform(visualization=False, enable_cameras=True)
+def test_timestamps_no_camera_delay():
+    platform = TriFingerPlatform(
+        visualization=False, enable_cameras=True, camera_delay_steps=0
+    )
     action = platform.Action()
 
     # ensure the camera frame rate is set to 10 Hz
@@ -26,16 +28,16 @@ def test_timestamps():
     first_stamp_s = first_stamp_ms / 1000
 
     camera_obs = platform.get_camera_observation(t)
-    assert first_stamp_ms == camera_obs.cameras[0].timestamp
-    assert first_stamp_ms == camera_obs.cameras[1].timestamp
-    assert first_stamp_ms == camera_obs.cameras[2].timestamp
+    assert first_stamp_s == camera_obs.cameras[0].timestamp
+    assert first_stamp_s == camera_obs.cameras[1].timestamp
+    assert first_stamp_s == camera_obs.cameras[2].timestamp
 
     # Test time stamps of observations t+1 (with the current implementation,
     # the observation should be exactly the same as for t).
     camera_obs_next = platform.get_camera_observation(t + 1)
-    assert first_stamp_ms == camera_obs_next.cameras[0].timestamp
-    assert first_stamp_ms == camera_obs_next.cameras[1].timestamp
-    assert first_stamp_ms == camera_obs_next.cameras[2].timestamp
+    assert first_stamp_s == camera_obs_next.cameras[0].timestamp
+    assert first_stamp_s == camera_obs_next.cameras[1].timestamp
+    assert first_stamp_s == camera_obs_next.cameras[2].timestamp
 
     # Second time step
     t = platform.append_desired_action(action)
@@ -62,6 +64,195 @@ def test_timestamps():
     assert nth_stamp_s == camera_obs.cameras[0].timestamp
     assert nth_stamp_s == camera_obs.cameras[1].timestamp
     assert nth_stamp_s == camera_obs.cameras[2].timestamp
+
+
+def test_camera_timestamps_with_camera_delay_simple():
+    # Basic test with simple values: Camera update every 2 steps, delay of 1
+    # step.
+    platform = TriFingerPlatform(
+        visualization=False, enable_cameras=True, camera_delay_steps=1
+    )
+    action = platform.Action()
+
+    # set camera rate to 100 fps so we need less stepping in this test
+    platform.camera_rate_fps = 500
+    assert platform._compute_camera_update_step_interval() == 2
+
+    initial_stamp_s = platform.get_timestamp_ms(0) / 1000
+
+    # first step triggers camera (we get the initial observation at this point)
+    t = platform.append_desired_action(action)
+    assert t == 0
+    camera_obs = platform.get_camera_observation(t)
+    assert initial_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    trigger1_stamp_s = platform.get_timestamp_ms(t) / 1000
+
+    # in second step observation is ready but still has stamp zero
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger1_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    # in third step new observation is triggered but due to delay we still get
+    # the old one
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger1_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    trigger2_stamp_s = platform.get_timestamp_ms(t) / 1000
+    assert trigger2_stamp_s > trigger1_stamp_s
+
+    # in forth step the new observation is ready
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger2_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    # again trigger but we get previous observation due to delay
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger2_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    trigger3_stamp_s = platform.get_timestamp_ms(t) / 1000
+    assert trigger3_stamp_s > trigger2_stamp_s
+
+    # and there should be an update again
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger3_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger3_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger3_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+
+def test_camera_timestamps_with_camera_delay_less_than_rate():
+    # A bit more complex example (probably redundant with the simple one above
+    # but since I already implemented it, let's keep it).
+
+    platform = TriFingerPlatform(
+        visualization=False, enable_cameras=True, camera_delay_steps=10
+    )
+    action = platform.Action()
+
+    # ensure the camera frame rate is set to 10 Hz
+    assert platform.camera_rate_fps == 10
+    assert platform._compute_camera_update_step_interval() == 100
+
+    first_stamp_s = platform.get_timestamp_ms(0) / 1000
+
+    # The start is a bit tricky because of the initial observation which has
+    # timestamp 0 but the next observation is triggered in the first step,
+    # resulting in the same timestamp.  So first step 100 times, until the next
+    # camera update is triggered.
+    for i in range(100):
+        t = platform.append_desired_action(action)
+
+        # In each step, we still should see the camera observation from step 0
+        cameras = platform.get_camera_observation(t).cameras
+        assert first_stamp_s == cameras[0].timestamp, f"i={i}, t={t}"
+        assert first_stamp_s == cameras[1].timestamp, f"i={i}, t={t}"
+        assert first_stamp_s == cameras[2].timestamp, f"i={i}, t={t}"
+
+    assert t == 99
+
+    # one more step to trigger the next camera update
+    t = platform.append_desired_action(action)
+    second_stamp_s = platform.get_timestamp_ms(t) / 1000
+
+    # The next observation should be triggered now but due to the delay, we
+    # should still see the old observation for the next 9 steps
+    for i in range(9):
+        t = platform.append_desired_action(action)
+        cameras = platform.get_camera_observation(t).cameras
+        assert first_stamp_s == cameras[0].timestamp, f"i={i}, t={t}"
+        assert first_stamp_s == cameras[1].timestamp, f"i={i}, t={t}"
+        assert first_stamp_s == cameras[2].timestamp, f"i={i}, t={t}"
+
+    # after the next step, we should see an updated camera observation which
+    # again persists for 100 steps
+    for i in range(100):
+        t = platform.append_desired_action(action)
+        cameras = platform.get_camera_observation(t).cameras
+        assert second_stamp_s == cameras[0].timestamp, f"i={i}, t={t}"
+        assert second_stamp_s == cameras[1].timestamp, f"i={i}, t={t}"
+        assert second_stamp_s == cameras[2].timestamp, f"i={i}, t={t}"
+
+    # and now the next update should be there
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert second_stamp_s < camera_obs.cameras[0].timestamp
+
+
+def test_camera_timestamps_with_camera_delay_more_than_rate():
+    # In this test the delay is higher than the camera rate, so this results in
+    # the effective rate to be reduced.
+    # Use small numbers (camera update interval 2 and delay 3) to keep the test
+    # manageable.
+
+    platform = TriFingerPlatform(
+        visualization=False, enable_cameras=True, camera_delay_steps=3
+    )
+    action = platform.Action()
+
+    # set high camera rate so we need less stepping in this test
+    platform.camera_rate_fps = 500
+    assert platform._compute_camera_update_step_interval() == 2
+
+    initial_stamp_s = platform.get_timestamp_ms(0) / 1000
+
+    # first step triggers camera (we get the initial observation at this point)
+    t = platform.append_desired_action(action)
+    assert t == 0
+    camera_obs = platform.get_camera_observation(t)
+    assert initial_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    trigger1_stamp_s = platform.get_timestamp_ms(t) / 1000
+
+    # now it takes 3 steps until we actually see the new observation
+    t = platform.append_desired_action(action)
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert initial_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert initial_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger1_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    # Only now, one step later, the next update is triggered
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger1_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+
+    trigger2_stamp_s = platform.get_timestamp_ms(t) / 1000
+    assert trigger2_stamp_s > trigger1_stamp_s
+
+    # And again it takes 3 steps until we actually see the new observation
+    t = platform.append_desired_action(action)
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger1_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger1_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
+    t = platform.append_desired_action(action)
+    camera_obs = platform.get_camera_observation(t)
+    assert trigger2_stamp_s == camera_obs.cameras[0].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[1].timestamp, f"t={t}"
+    assert trigger2_stamp_s == camera_obs.cameras[2].timestamp, f"t={t}"
 
 
 def test_get_camera_observation_timeindex():

--- a/trifinger_simulation/trifinger_platform.py
+++ b/trifinger_simulation/trifinger_platform.py
@@ -22,15 +22,13 @@ class ObjectType(enum.Enum):
 class ObjectPose:
     """A pure-python copy of trifinger_object_tracking::ObjectPose."""
 
-    __slots__ = ["position", "orientation", "timestamp", "confidence"]
+    __slots__ = ["position", "orientation", "confidence"]
 
     def __init__(self):
         #: array: Position (x, y, z) of the object.  Units are meters.
         self.position = np.zeros(3)
         #: array: Orientation of the object as (x, y, z, w) quaternion.
         self.orientation = np.zeros(4)
-        #: float: Timestamp when the pose was observed.
-        self.timestamp = 0.0
         #: float: Estimate of the confidence for this pose observation.
         self.confidence = 1.0
 
@@ -286,14 +284,6 @@ class TriFingerPlatform:
                 self._camera_observation_t.cameras[
                     i
                 ].timestamp = camera_timestamp_s
-
-            if self._has_object_tracking:
-                self._camera_observation_t.object_pose.timestamp = (
-                    camera_timestamp_s
-                )
-                self._camera_observation_t.filtered_object_pose.timestamp = (
-                    camera_timestamp_s
-                )
 
         # write the desired action to the log
         camera_obs = self.get_camera_observation(t)

--- a/trifinger_simulation/trifinger_platform.py
+++ b/trifinger_simulation/trifinger_platform.py
@@ -142,6 +142,7 @@ class TriFingerPlatform:
         enable_cameras: bool = False,
         time_step_s: float = 0.001,
         object_type: ObjectType = ObjectType.COLORED_CUBE,
+        camera_delay_steps: int = 90,  # default based on real robot data
     ):
         """Initialize.
 
@@ -162,6 +163,11 @@ class TriFingerPlatform:
             object_type:  Which type of object to load.  This also influences
                 some other aspects: When using the cube, the camera observation
                 will contain an attribute ``object_pose``.
+            camera_delay_steps:  Number of time steps by which camera
+                observations are held back after they are generated.  This is
+                used to simulate the delay of the camera observation that is
+                happening on the real system due to processing (mostly the
+                object detection).
         """
         #: Camera rate in frames per second.  Observations of camera and
         #: object pose will only be updated with this rate.
@@ -173,8 +179,14 @@ class TriFingerPlatform:
         #: Simulation time step
         self._time_step = time_step_s
 
-        # first camera update in the first step
-        self._next_camera_update_step = 0
+        # Camera delay in robot time steps
+        self._camera_delay_steps = camera_delay_steps
+
+        # Time step at which the next camera update is triggered
+        self._next_camera_trigger_t = 0
+        # Time step at which the last triggered camera update is ready (used to
+        # simulate delay).
+        self._next_camera_observation_ready_t: typing.Optional[int] = None
 
         # Initialize robot, object and cameras
         # ====================================
@@ -247,14 +259,17 @@ class TriFingerPlatform:
         }
 
         # get initial camera observation
-        self._camera_observation_t = self._get_current_camera_observation(0)
+        self._delayed_camera_observation = (
+            self._get_current_camera_observation(0)
+        )
+        self._camera_observation_t = self._delayed_camera_observation
 
     def get_time_step(self):
         """Get simulation time step in seconds."""
         return self._time_step
 
-    def _compute_camera_update_step_interval(self):
-        return (1.0 / self.camera_rate_fps) / self._time_step
+    def _compute_camera_update_step_interval(self) -> int:
+        return round((1.0 / self.camera_rate_fps) / self._time_step)
 
     def append_desired_action(self, action):
         """
@@ -264,26 +279,16 @@ class TriFingerPlatform:
         Arguments/return value are the same as for
         :meth:`pybullet.SimFinger.append_desired_action`.
         """
-        # update camera and object observations only with the rate of the
-        # cameras
-        next_t = self.simfinger._t + 1
-        has_camera_update = next_t >= self._next_camera_update_step
-        if has_camera_update:
-            self._next_camera_update_step += (
-                self._compute_camera_update_step_interval()
-            )
-            self._camera_observation_t = self._get_current_camera_observation()
+        camera_triggered = self._camera_update()
 
         t = self.simfinger.append_desired_action(action)
 
         # The correct timestamp can only be acquired now that t is given.
-        # Update it accordingly in the object and camera observations
-        if has_camera_update:
+        # Update it accordingly in the camera observations
+        if camera_triggered:
             camera_timestamp_s = self.get_timestamp_ms(t) / 1000
-            for i in range(len(self._camera_observation_t.cameras)):
-                self._camera_observation_t.cameras[
-                    i
-                ].timestamp = camera_timestamp_s
+            for camera_ in self._delayed_camera_observation.cameras:
+                camera_.timestamp = camera_timestamp_s
 
         # write the desired action to the log
         camera_obs = self.get_camera_observation(t)
@@ -299,6 +304,37 @@ class TriFingerPlatform:
         self._action_log["actions"].append(copy.deepcopy(log_entry))
 
         return t
+
+    def _camera_update(self) -> bool:
+        # update camera and object observations only with the rate of the
+        # cameras
+        next_t = self.simfinger._t + 1
+
+        # only trigger if no observation is still in work
+        trigger_camera = (self._next_camera_observation_ready_t is None) and (
+            next_t >= self._next_camera_trigger_t
+        )
+
+        if trigger_camera:
+            self._delayed_camera_observation = (
+                self._get_current_camera_observation()
+            )
+            self._next_camera_trigger_t += (
+                self._compute_camera_update_step_interval()
+            )
+            self._next_camera_observation_ready_t = (
+                next_t + self._camera_delay_steps
+            )
+
+        is_camera_observation_ready = (
+            self._next_camera_observation_ready_t is not None
+        ) and (next_t >= self._next_camera_observation_ready_t)
+
+        if is_camera_observation_ready:
+            self._camera_observation_t = self._delayed_camera_observation
+            self._next_camera_observation_ready_t = None
+
+        return trigger_camera
 
     def _get_current_object_pose(self):
         assert self._has_object_tracking


### PR DESCRIPTION
## Description

- Remove timestamp from ObjectPose (it has already been removed on the real robot some time ago).
- Simulate delay of camera observations (to account for time needed for object detection on the real system).

This is an alternative implementation to #83.  The delay is implemented by using two different trigger times:  `_next_camera_trigger_t` which marks the next time step at which a new observation is queried from the cameras (aka images are rendered) and `_next_camera_observation_read_t` which marks the time at which the observation that is provided to the user gets updated with the observation from the last trigger.

Also added unit tests to make sure the timing works correctly.


## How I Tested

By running the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
