### PR TITLE
Set gym space dtypes to float64 and fix failing test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ master
 ------
 
 - Switch from setup.py to setup.cfg
+- Set dtypes of gym spaces to np.float64
 
 
 Version 1.4.0

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import gym
 
+import trifinger_simulation.gym_wrapper  # noqa
 from trifinger_simulation.sim_finger import SimFinger
 
 
@@ -31,7 +32,7 @@ class TestSimulationDeterminisim(unittest.TestCase):
 
         def run():
             finger.reset_finger_positions_and_velocities(start_position)
-            for i in range(30):
+            for _ in range(30):
                 finger._set_desired_action(action)
                 finger._step_simulation()
             return finger._get_latest_observation()

--- a/trifinger_simulation/gym_wrapper/finger_spaces.py
+++ b/trifinger_simulation/gym_wrapper/finger_spaces.py
@@ -125,6 +125,7 @@ class FingerSpaces:
         return spaces.Box(
             low=np.array(observation_lower_bounds),
             high=np.array(observation_higher_bounds),
+            dtype=np.float64,
         )
 
     def get_unscaled_action_space(self):
@@ -134,7 +135,7 @@ class FingerSpaces:
         return spaces.Box(
             low=self.action_bounds["low"],
             high=self.action_bounds["high"],
-            dtype=np.float32,
+            dtype=np.float64,
         )
 
     def get_scaled_observation_space(self):
@@ -146,6 +147,7 @@ class FingerSpaces:
         return spaces.Box(
             low=-np.ones_like(unscaled_observation_space.low),
             high=np.ones_like(unscaled_observation_space.high),
+            dtype=np.float64,
         )
 
     def get_scaled_action_space(self):
@@ -156,4 +158,5 @@ class FingerSpaces:
         return spaces.Box(
             low=-np.ones(3 * self.num_fingers),
             high=np.ones(3 * self.num_fingers),
+            dtype=np.float64,
         )


### PR DESCRIPTION
## Description
See commits for details.

## How I Tested

By running unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
