### PR TITLE
fix: Do not call gym.Env.seed()

### DIFF
--- a/trifinger_simulation/gym_wrapper/envs/trifinger_reach.py
+++ b/trifinger_simulation/gym_wrapper/envs/trifinger_reach.py
@@ -182,7 +182,6 @@ class TriFingerReach(gym.Env):
         else:
             self.next_start_time = None
 
-        self.seed()
         self.reset()
 
     def _compute_reward(self, observation, goal):


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The `seed()` method has been removed from Env in recent versions of gym (instead the seed can be passed to `reset()`).
Since calling it without arguments anyway seems pointless, just remove the call altogether.


## How I Tested

Unit tests


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
