### PR TITLE
fix: Comment in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ packages = find:
 install_requires =
     numpy >=1.19.1
     scipy >=1.5.4
-    pin >=2.4.7  # pinocchio
+    # pinocchio
+    pin >=2.4.7
     pybullet >=3.0.8
     gym >=0.23.1
     opencv-python >=4.2.0.34


### PR DESCRIPTION
## Description

Apparently setup.cfg does not support comments at the end of a line. Instead, the comment needs to be in its own line.

This had caused an error when running tests via `colcon test`.

