### PR TITLE
Add deprecation warning to pinocchio_utils

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -15,10 +15,10 @@ on: pull_request
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # checkout to subdirectory, otherwise the tests fail for some reason
           path: trifinger_simulation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - uses: actions/checkout@v2
       with:
         path: trifinger_simulation

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -4,9 +4,9 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.0.0
+    - uses: actions/checkout@v4
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,10 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install mypy
         run: |
           python3 -m pip install mypy types-PyYAML types-setuptools
@@ -26,10 +26,10 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install
         run: |
           python3 -m pip install flake8
@@ -43,6 +43,6 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - uses: psf/black@stable

--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,10 +7,9 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v4
     - name: Check for FIXMEs
-      uses: luator/github_action_check_new_todos@v1.0.0
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: FIXME
           base_ref: origin/${{ github.base_ref }}
@@ -19,10 +18,9 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v4
     - name: Check for TODOs
-      uses: luator/github_action_check_new_todos@v1.0.0
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: TODO
           base_ref: origin/${{ github.base_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Update pip
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,21 +1,34 @@
 trifinger_simulation Changelog
 ==============================
 
-master
-------
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(at least for versions > 1.4.1).
+
+
+## [Unreleased]
+### Added
 - Add py.typed marker for mypy
+- screenshot_mode.py to run simulation without visualisations (for nicer screenshots).
+
+### Deprecated
+- The `pinocchio_utils` module is deprecated and will be removed in a future release.
+  Use the one from robot_properties_fingers instead.
+
+### Fixed
+- Fixed a rounding error that occasionally resulted in NaN values when evaluating states
+  in the "move_cuboid" task.
 
 
-Version 1.4.1
--------------
+## 1.4.1 - 2022-06-24
 
 - Switch from setup.py to setup.cfg
 - Set dtypes of gym spaces to np.float64
 
 
-Version 1.4.0
--------------
+## 1.4.0 - 2022-06-23
 
 - Nicer rendering of the boundary (#68)
 - Change initial pose of camera in PyBullet GUI (#68)
@@ -26,7 +39,6 @@ Version 1.4.0
 - Optionally compute tip velocities in forward kinematics (#85)
 - Cleanup the code and add more unit tests
 
-Version 1.3.0
--------------
+## 1.3.0 - 2021-08-04
 
 There is no changelog for this or earlier versions.

--- a/demos/demo_control.py
+++ b/demos/demo_control.py
@@ -44,7 +44,6 @@ def main():
         position_goals = visual_objects.Marker(number_of_goals=num_fingers)
 
     while True:
-
         if args.control_mode == "position":
             desired_joint_positions = np.array(
                 sample.random_joint_positions(number_of_fingers=num_fingers)

--- a/demos/demo_load_gym_env.py
+++ b/demos/demo_load_gym_env.py
@@ -23,7 +23,6 @@ def main():
         )
 
     elif args.env == "reach":
-
         smoothing_params = {
             "num_episodes": 700,
             "start_after": 3.0 / 7.0,

--- a/scripts/playback_data.py
+++ b/scripts/playback_data.py
@@ -61,7 +61,6 @@ def main_finger(finger_type, data_file):
 
 
 def trifinger_goal_space_transforms(finger_type, data):
-
     rot_z_120 = tf.euler_matrix(0, 0, np.deg2rad(-120))[:3, :3]
 
     if finger_type == "trifingerone":
@@ -89,7 +88,6 @@ def trifinger_goal_space_transforms(finger_type, data):
 
 
 def main_trifinger(finger_type, data_file_0, data_file_120, data_file_240):
-
     finger = SimFinger(enable_visualization=True, finger_type=finger_type)
     goal_marker = visual_objects.Marker(number_of_goals=3)
 

--- a/scripts/plot_tip_position_trajectories.py
+++ b/scripts/plot_tip_position_trajectories.py
@@ -98,7 +98,6 @@ def main():
             ax = [ax]
 
         for title, ylabel, a, y in plains:
-
             for i in range(start, end):
                 data = episodes[i]
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -76,7 +76,7 @@ def test_camera_parameters_load():
     with open(config_file, "r") as f:
         params = sim_camera.CameraParameters.load(f)
 
-    assert type(params) == sim_camera.CameraParameters
+    assert type(params) is sim_camera.CameraParameters
     assert params.name == "camera180"
     assert params.width == 720
     assert params.height == 540

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -45,7 +45,6 @@ class TestSimulationDeterminisim(unittest.TestCase):
         np.testing.assert_array_equal(first_run.velocity, second_run.velocity)
 
     def test_reach_rollouts(self):
-
         smoothing_params = {
             "num_episodes": 10,
             # ratio of total training time after which smoothing starts

--- a/trifinger_simulation/pinocchio_utils.py
+++ b/trifinger_simulation/pinocchio_utils.py
@@ -1,8 +1,25 @@
 """Wrappers around Pinocchio for easy forward and inverse kinematics."""
 import typing
+import warnings
 
 import numpy as np
 import pinocchio
+
+
+warnings.warn(
+    "The pinocchio_utils module has been moved to the robot_properties_fingers package."
+    "  Please update your code accordingly.  This version in trifinger_simulation is"
+    " deprecated and will be removed soon!",
+    FutureWarning,
+    stacklevel=1,
+)
+
+
+# === IMPORTANT: This class is deprecated!  See warning above.
+# The implementation here is kept for now, as robot_properties_fingers is not yet
+# pip-installable but should be removed as soon as possible.
+# Please do not make any changes here anymore but instead add new features/fixes/etc. in
+# robot_properties_fingers.
 
 
 class Kinematics:

--- a/trifinger_simulation/sim_finger.py
+++ b/trifinger_simulation/sim_finger.py
@@ -454,7 +454,6 @@ class SimFinger:
             )
 
     def __set_pybullet_motor_torques(self, motor_torques):
-
         pybullet.setJointMotorControlArray(
             bodyUniqueId=self.finger_id,
             jointIndices=self.pybullet_joint_indices,
@@ -836,7 +835,6 @@ class SimFinger:
             table_colour = (0.18, 0.15, 0.19, 1.0)
             high_border_colour = (0.73, 0.68, 0.72, 1.0)
             if high_border:
-
                 # use a simple cuboid for the table
                 self._table_id = collision_objects.Cuboid(
                     position=(0, 0, -0.005),

--- a/trifinger_simulation/tasks/move_cube/replay_action_log.py
+++ b/trifinger_simulation/tasks/move_cube/replay_action_log.py
@@ -28,7 +28,6 @@ from trifinger_simulation.tasks import move_cube
 
 
 def replay_action_log(logfile, difficulty, initial_pose, goal_pose):
-
     with open(logfile, "rb") as fh:
         log = pickle.load(fh)
 

--- a/trifinger_simulation/tasks/move_cube/run_evaluate_policy.py
+++ b/trifinger_simulation/tasks/move_cube/run_evaluate_policy.py
@@ -87,7 +87,6 @@ def run_evaluate_policy(sample: TestSample):
 
 
 def main(output_directory: str):
-
     if not os.path.isdir(output_directory):
         print(
             "'{}' does not exist or is not a directory.".format(


### PR DESCRIPTION
## Description

Mark the pinocchio_utils module as deprecated (to be removed in a future release).  The module has been moved to the robot_properties_fingers package and will be maintained there from now on.

For now keep the implementation here as robot_properties_fingers is currently not pip-installable (so removing it would be a problem for users who use the pip-installation of trifinger_simulation).  It can be removed as soon as robot_properties_fingers is converted to pure Python and published on PyPI (which is a long-standing TODO anyway).

## How I Tested

Ran a demo script that uses the module.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/pull/13
