### PR TITLE
Fix Documentation Build

### DIFF
--- a/.github/workflows/doc_test.yml
+++ b/.github/workflows/doc_test.yml
@@ -1,0 +1,39 @@
+# build docs using sphinx and deploy to branch gh-pages
+name: Documentation
+on:
+  workflow_dispatch:
+
+# NOTE: for some reason that is not clear to me, `pip install` of required
+# packages (sphinx, etc.) was installing things to a weird location outside of
+# PATH when the repo is checked out directly in the working dir.  The
+# corresponding warning from pip:
+#
+#     WARNING: The scripts sphinx-apidoc, sphinx-autogen, sphinx-build and
+#     sphinx-quickstart are installed in
+#     '/home/runner/.local/lib/trifinger_simulation' which is not on PATH
+#
+# This resulted in the build to fail later one, as sphinx-build was not in the
+# PATH.
+#
+# This is solved by checking out to a subdirectory "trifinger_simulation".
+
+jobs:
+  build_only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - uses: actions/checkout@v4
+        with:
+          path: trifinger_simulation
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Build and deploy documentation
+        uses: sphinx-notes/pages@v3
+        with:
+          checkout: false  # checkout is done manually above (see NOTE for reason)
+          repository_path: trifinger_simulation
+          requirements_path: docs/requirements.txt
+          publish: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,3 +55,4 @@ jobs:
           checkout: false  # checkout is done manually above (see NOTE for reason)
           repository_path: trifinger_simulation
           requirements_path: docs/requirements.txt
+          publish: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,30 +26,8 @@ on:
 # This is solved by checking out to a subdirectory "trifinger_simulation".
 
 jobs:
-  build:
+  build_and_deploy:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - uses: actions/checkout@v2
-      with:
-        path: trifinger_simulation
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-    - name: Build and commit documentation
-      uses: sphinx-notes/pages@v2
-      with:
-        repository_path: trifinger_simulation
-        requirements_path: docs/requirements.txt
-
-    - name: Upload documentation artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: trifinger_simulation
-
-  deploy:
-    # Add a dependency to the build job
-    needs: build
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
@@ -61,9 +39,19 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - uses: actions/checkout@v4
+        with:
+          path: trifinger_simulation
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Build and deploy documentation
+        uses: sphinx-notes/pages@v3
+        with:
+          checkout: false  # checkout is done manually above (see NOTE for reason)
+          repository_path: trifinger_simulation
+          requirements_path: docs/requirements.txt

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -12,7 +12,7 @@ Stand-alone installation using pip
 
 .. note::
 
-   We are developing for Python 3.8.  Other versions may work as well but are
+   We are developing for Python 3.10.  Other versions may work as well but are
    not officially tested.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 gym==0.18.0
-numpy==1.19.5; python_version<"3.8"
-numpy==1.20.3; python_version>="3.8"
+numpy==1.20.3
 opencv-python==4.2.0.34
 pin==2.6.0
 pybullet==3.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-gym==0.18.0
-numpy==1.20.3
-opencv-python==4.2.0.34
-pin==2.6.0
-pybullet==3.0.8
-pytest==6.2.3
-pyyaml==5.3.1
+numpy>=1.19.1
+scipy>=1.5.4
+pin>=2.4.7
+pybullet>=3.0.8
+gym>=0.23.1
+opencv-python>=4.2.0.34
+pyyaml>=5.3.1


### PR DESCRIPTION
## Description
- Update the documentation workflow.  The new sphinx-notes/pages action now directly publishes on its own, so the whole workflow can be simplified.
- Do not require explicit versions of dependencies (hopefully this fixes a build issue on master)

## How I Tested

~~Through "workflow_dispatch" trigger of the documentation workflow.~~
Not working as desired due to environment stuff.  Will merge and see what happens...
