### PR TITLE
chore: Add workflow_dispatch to documentation build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
 # build docs using sphinx and deploy to branch gh-pages
-name: Pages
+name: Documentation
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to GitHub Pages (disable to only test the build)"
+        type: boolean
+        default: false
 
 # NOTE: for some reason that is not clear to me, `pip install` of required
 # packages (sphinx, etc.) was installing things to a weird location outside of


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Rename the documentation workflow from "Pages" to "Documentation" so its more obvious what it is about.
- Add workflow_dispatch event so it can be triggered manually.  Add an option to disable publishing in this case, to allow testing only the build (useful for branches before merging).
