### PR TITLE
Fix and simplify documentation build workflows

### DIFF
--- a/.github/workflows/doc_test.yml
+++ b/.github/workflows/doc_test.yml
@@ -3,37 +3,13 @@ name: Documentation (Test)
 on:
   workflow_dispatch:
 
-# NOTE: for some reason that is not clear to me, `pip install` of required
-# packages (sphinx, etc.) was installing things to a weird location outside of
-# PATH when the repo is checked out directly in the working dir.  The
-# corresponding warning from pip:
-#
-#     WARNING: The scripts sphinx-apidoc, sphinx-autogen, sphinx-build and
-#     sphinx-quickstart are installed in
-#     '/home/runner/.local/lib/trifinger_simulation' which is not on PATH
-#
-# This resulted in the build to fail later one, as sphinx-build was not in the
-# PATH.
-#
-# This is solved by checking out to a subdirectory "trifinger_simulation".
-
 jobs:
   build_only:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - uses: actions/checkout@v4
-        with:
-          path: trifinger_simulation
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-
       - name: Build and deploy documentation
         uses: sphinx-notes/pages@v3
         with:
-          checkout: false  # checkout is done manually above (see NOTE for reason)
-          documentation_path: trifinger_simulation/docs
-          requirements_path: trifinger_simulation/docs/requirements.txt
+          documentation_path: docs
+          requirements_path: docs/requirements.txt
           publish: false

--- a/.github/workflows/doc_test.yml
+++ b/.github/workflows/doc_test.yml
@@ -34,6 +34,6 @@ jobs:
         uses: sphinx-notes/pages@v3
         with:
           checkout: false  # checkout is done manually above (see NOTE for reason)
-          repository_path: trifinger_simulation
-          requirements_path: docs/requirements.txt
+          documentation_path: trifinger_simulation/docs
+          requirements_path: trifinger_simulation/docs/requirements.txt
           publish: false

--- a/.github/workflows/doc_test.yml
+++ b/.github/workflows/doc_test.yml
@@ -1,5 +1,5 @@
 # build docs using sphinx and deploy to branch gh-pages
-name: Documentation
+name: Documentation (Test)
 on:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,20 +11,6 @@ on:
         type: boolean
         default: false
 
-# NOTE: for some reason that is not clear to me, `pip install` of required
-# packages (sphinx, etc.) was installing things to a weird location outside of
-# PATH when the repo is checked out directly in the working dir.  The
-# corresponding warning from pip:
-#
-#     WARNING: The scripts sphinx-apidoc, sphinx-autogen, sphinx-build and
-#     sphinx-quickstart are installed in
-#     '/home/runner/.local/lib/trifinger_simulation' which is not on PATH
-#
-# This resulted in the build to fail later one, as sphinx-build was not in the
-# PATH.
-#
-# This is solved by checking out to a subdirectory "trifinger_simulation".
-
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -40,19 +26,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - uses: actions/checkout@v4
-        with:
-          path: trifinger_simulation
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-
       - name: Build and deploy documentation
         uses: sphinx-notes/pages@v3
         with:
-          checkout: false  # checkout is done manually above (see NOTE for reason)
           documentation_path: trifinger_simulation/docs
           requirements_path: trifinger_simulation/docs/requirements.txt
           publish: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,6 @@ jobs:
         uses: sphinx-notes/pages@v3
         with:
           checkout: false  # checkout is done manually above (see NOTE for reason)
-          repository_path: trifinger_simulation
-          requirements_path: docs/requirements.txt
+          documentation_path: trifinger_simulation/docs
+          requirements_path: trifinger_simulation/docs/requirements.txt
           publish: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}


### PR DESCRIPTION
## Description

It seems the issue due to which the package was checked out to a sub-directory does not exist anymore with v3 of the pages action, so we can get rid of the workaround and make the workflow much simpler.

Also fix the arguments of the pages action, which have changed a bit in v3.
