### PR TITLE
build: use script_dir instead of script-dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [develop]
-script-dir=$base/lib/trifinger_simulation
+script_dir=$base/lib/trifinger_simulation
 [install]
-install-scripts=$base/lib/trifinger_simulation
+install_scripts=$base/lib/trifinger_simulation
 
 [metadata]
 name = trifinger_simulation


### PR DESCRIPTION
## Description

`script-dir` and `install-scripts` are deprecated, one should use `script_dir`/`install_scripts` now.
Changing this silences a warning and will probably make the package more future-proof.


## How I Tested

Build the package with colcon and ran a demo script to test.