### PR TITLE
fix: Use np.min to avoid mypy error

### DIFF
--- a/trifinger_simulation/tasks/move_cuboid.py
+++ b/trifinger_simulation/tasks/move_cuboid.py
@@ -23,7 +23,7 @@ _ARENA_RADIUS = 0.195
 _cube_3d_radius = np.linalg.norm(_CUBOID_HALF_SIZE)
 _max_cube_com_distance_to_center = _ARENA_RADIUS - _cube_3d_radius
 
-_min_height = min(_CUBOID_HALF_SIZE)
+_min_height = np.min(_CUBOID_HALF_SIZE)
 _max_height = 0.1
 
 


### PR DESCRIPTION
Mypy complained about this because the input is a numpy type rather than
a native Python type.
It was still working as expected but since changing `min` to `np.min` is
trivial and makes the type checker happy, let's simply do that.
This should not change the behaviour of the code in any way.