### PR TITLE
fix: Require NumPy <2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy >=1.19.1
+    numpy >=1.19.1,<2
     scipy >=1.5.4
     # pinocchio
     pin >=2.4.7


### PR DESCRIPTION
There are issues with NumPy 2.  Until they are resolved, pin the version to <2.