### PR TITLE
Avoid failure if pybullet doesn't use numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the "move_cuboid" task.
 - Fixed included URDF files of (Tri)FingerPro (see [robot_properties_fingers #15
   ](https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/pull/15)).
+- Fixed a crash caused by rendered camera images having the wrong format if PyBullet
+  does not use NumPy.
 
 ### Removed
 - trifinger_simulation does no longer maintain a copy of the robot model files for the

--- a/trifinger_simulation/camera.py
+++ b/trifinger_simulation/camera.py
@@ -236,6 +236,15 @@ class Camera(BaseCamera):
             renderer=renderer,
             physicsClientId=self._pybullet_client_id,
         )
+        # Depending on whatever, pybullet may not use NumPy in some installations, see
+        # https://github.com/bulletphysics/bullet3/issues/4523.
+        # To make sure our code still works, catch that and convert the image
+        # accordingly
+        if isinstance(img, tuple):
+            img = np.array(img, dtype=np.uint8).reshape(
+                self._height, self._width, 4
+            )
+
         # remove the alpha channel
         return img[:, :, :3]
 
@@ -482,6 +491,15 @@ class CalibratedCamera(BaseCamera):
             renderer=renderer,
             physicsClientId=self._pybullet_client_id,
         )
+        # Depending on whatever, pybullet may not use NumPy in some installations, see
+        # https://github.com/bulletphysics/bullet3/issues/4523.
+        # To make sure our code still works, catch that and convert the image
+        # accordingly
+        if isinstance(img, tuple):
+            img = np.array(img, dtype=np.uint8).reshape(
+                self._render_height, self._render_width, 4
+            )
+
         # remove the alpha channel
         img = img[:, :, :3]
 


### PR DESCRIPTION

## Description

PyBullet may not use NumPy in some installations (see https://github.com/bulletphysics/bullet3/issues/4523). To make sure our code still works, catch that and convert the image accordingly.

## How I Tested

Unit tests and by running `demo_cameras.py` in an environment where pybullet did not use numpy.
