### PR TITLE
Change default camera resolution to 540x540

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2024-07-30
 ### Changed
-- BREAKING: Migrated from gym to gymnasium.
+- Migrated from gym to gymnasium.
+- Default resolution of rendered camera images is changed from 270 to 540 pixels to
+  match the behaviour of the real robot.
 
 ### Added
 - Add py.typed marker for mypy

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -100,9 +100,7 @@ def main():
             images = cameras.get_images()
             # images are rgb --> convert to bgr for opencv
             images = [cv2.cvtColor(img, cv2.COLOR_RGB2BGR) for img in images]
-            cv2.imshow("camera60", images[0])
-            cv2.imshow("camera180", images[1])
-            cv2.imshow("camera300", images[2])
+            cv2.imshow("camera60 | camera180 | camera300", np.hstack(images))
             key = cv2.waitKey(int(time_step * 1000))
 
             if key == ord("s"):

--- a/trifinger_simulation/camera.py
+++ b/trifinger_simulation/camera.py
@@ -157,7 +157,7 @@ class Camera(BaseCamera):
         self,
         camera_position,
         camera_orientation,
-        image_size=(270, 270),
+        image_size=(540, 540),
         field_of_view=52,
         near_plane_distance=0.001,
         far_plane_distance=100.0,


### PR DESCRIPTION
## Description

The downsampling to 270x270 is removed from trifinger_cameras, therefore, change the default resolution to 540x540 here, so it matches with the real robots.


## How I Tested

By running demo_cameras.py
